### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/). 53 tools to query and manage your Mailchimp account directly from Claude.
 
+<a href="https://glama.ai/mcp/servers/@damientilman/mailchimp-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@damientilman/mailchimp-mcp/badge" alt="Mailchimp MCP server" />
+</a>
+
 ## Features
 
 **Read**


### PR DESCRIPTION
This PR adds a badge for the [Mailchimp MCP](https://glama.ai/mcp/servers/@damientilman/mailchimp-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@damientilman/mailchimp-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@damientilman/mailchimp-mcp/badge" alt="Mailchimp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.