### PR TITLE
Release v0.3.0: audience CRUD, advanced reports, A/B campaigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05
+
+### Added
+- **A/B (variate) campaigns**: `create_campaign` now accepts `campaign_type='variate'`
+  and a `variate_settings_json` payload describing subject lines / from names / send
+  times / contents to test, the winner criterion, the test sample size, and the
+  wait time before declaring a winner.
+- **Audience lifecycle**: new `create_audience` and `delete_audience` tools for full
+  list creation and removal (closes #9).
+- **Advanced reports**: new `get_campaign_advice`, `get_campaign_locations`, and
+  `get_eepurl_activity` tools for post-send feedback, geographic open breakdowns,
+  and social sharing stats (closes #13).
+- Test coverage extended to all five new tools and to the variate campaign branch
+  of `create_campaign`.
+
+### Changed
+- Tool count bumped to **87** (was 82) — README, `pyproject.toml`, and `glama.json`
+  descriptions updated accordingly.
+
+## [0.2.1] - 2026-05
+
 ### Added
 - Test suite covering safety modes, request helpers, and a smoke test per tool family.
 - `CONTRIBUTING.md` with development setup and contribution guidelines.
 - `SECURITY.md` with vulnerability reporting policy.
 - CI improvements: linting (ruff), test execution, and coverage reporting.
 - Multi-stage Dockerfile running as a non-root user.
+
+### Changed
+- Documentation rewritten to be MCP-client agnostic; install sections now show
+  generic JSON/CLI examples rather than client-specific snippets.
 
 ## [0.2.0] - 2026-05
 
@@ -63,7 +88,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   landing pages, e-commerce, and batch operations.
 - MIT license, Python 3.10+ support, MCP-compatible via FastMCP.
 
-[Unreleased]: https://github.com/damientilman/mailchimp-mcp-server/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/damientilman/mailchimp-mcp-server/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/damientilman/mailchimp-mcp-server/releases/tag/v0.3.0
+[0.2.1]: https://github.com/damientilman/mailchimp-mcp-server/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/damientilman/mailchimp-mcp-server/releases/tag/v0.2.0
 [0.1.2]: https://github.com/damientilman/mailchimp-mcp-server/releases/tag/v0.1.2
 [0.1.1]: https://github.com/damientilman/mailchimp-mcp-server/releases/tag/v0.1.1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![MCP](https://img.shields.io/badge/MCP-compatible-green.svg)](https://modelcontextprotocol.io)
 
-The most complete [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/) — **82 tools** to query and manage your Mailchimp account from any MCP-compatible client, with read-only and dry-run safety modes.
+The most complete [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/) — **87 tools** to query and manage your Mailchimp account from any MCP-compatible client, with A/B campaign support, geographic reporting, and read-only / dry-run safety modes.
 
 Uses the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/api/) via [`requests`](https://pypi.org/project/requests/). Not based on the official [mailchimp-marketing-python](https://github.com/mailchimp/mailchimp-marketing-python) client. I hit too many issues with it so I went with raw HTTP calls instead.
 
@@ -204,12 +204,15 @@ Replace `mcp-cli` with your client's binary name. For read-only mode, add
 | `get_domain_performance` | Performance by email domain (gmail, outlook, etc.) |
 | `get_ecommerce_product_activity` | Revenue per product for a campaign |
 | `get_campaign_sub_reports` | Sub-reports (A/B tests, RSS, etc.) |
+| `get_campaign_advice` | Mailchimp's automated post-send feedback on a campaign |
+| `get_campaign_locations` | Geographic open data (country, region) |
+| `get_eepurl_activity` | Social sharing stats (Twitter, Facebook, referrers) |
 
 ### Campaigns (write)
 
 | Tool | Description |
 |---|---|
-| `create_campaign` | Create a new campaign draft (with optional segment targeting) |
+| `create_campaign` | Create a new campaign draft (regular or A/B `variate`, with optional segment targeting) |
 | `update_campaign` | Update settings or segment targeting of a campaign |
 | `set_campaign_content` | Set the HTML content of a campaign draft |
 | `schedule_campaign` | Schedule a campaign for a specific date/time |
@@ -254,6 +257,8 @@ Replace `mcp-cli` with your client's binary name. For read-only mode, add
 |---|---|
 | `batch_subscribe` | Batch add/update multiple members in an audience |
 | `update_audience` | Update audience settings (name, defaults, permission reminder) |
+| `create_audience` | Create a new audience with contact info and campaign defaults |
+| `delete_audience` | Permanently delete an audience and all its data |
 
 ### Segments & Tags
 
@@ -360,6 +365,9 @@ Once connected, you can ask your MCP client to perform requests like:
 - *"Set up a webhook to notify my app when new subscribers join"*
 - *"Unsubscribe user@example.com from my list"*
 - *"Show me the domain performance breakdown for my last campaign"*
+- *"Where in the world did people open my newsletter? Show me the geographic breakdown."*
+- *"Create an A/B test campaign with two subject lines and pick the winner by opens after 24 hours"*
+- *"What advice does Mailchimp have for improving my last campaign?"*
 - *"Pause my welcome automation"*
 - *"List all orders from my Shopify store this month"*
 

--- a/glama.json
+++ b/glama.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "mailchimp-mcp",
-  "description": "MCP server for the Mailchimp Marketing API. 82 tools for managing campaigns, audiences, members, templates, segments, automations, reports, e-commerce, and more.",
+  "description": "MCP server for the Mailchimp Marketing API. 87 tools for managing campaigns, audiences, members, templates, segments, automations, reports, e-commerce, A/B testing, and more.",
   "author": {
     "name": "Damien Tilman",
     "url": "https://github.com/damientilman"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mailchimp-mcp"
-version = "0.2.0"
+version = "0.3.0"
 description = "MCP server for the Mailchimp Marketing API — access campaigns, audiences, reports, and more from any MCP-compatible client."
 readme = "README.md"
 license = "MIT"

--- a/src/mailchimp_mcp_server/__init__.py
+++ b/src/mailchimp_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Mailchimp MCP Server — access Mailchimp data via the Model Context Protocol."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/src/mailchimp_mcp_server/server.py
+++ b/src/mailchimp_mcp_server/server.py
@@ -901,22 +901,125 @@ def update_audience(list_id: str, name: Optional[str] = None, from_name: Optiona
     }, indent=2)
 
 
+@mcp.tool()
+def create_audience(name: str, from_name: str, from_email: str, subject: str, language: str, company: str, address1: str, city: str, state: str, zip: str, country: str, permission_reminder: str, email_type_option: bool = False, address2: Optional[str] = None, phone: Optional[str] = None) -> str:
+    """Create a new audience (list) with required contact info, campaign defaults, and permission reminder.
+
+    Side effect: creates a billable audience under the Mailchimp plan. Mailchimp requires all
+    contact fields (company, address, city, state, zip, country) and CAN-SPAM-compliant permission
+    reminder text. Use update_audience to modify later, delete_audience for cleanup, or
+    list_audiences to verify creation.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+    Returns 400 error if any required field is missing or the plan audience limit is reached.
+
+    Args:
+        name: Audience display name shown in dashboard and audience picker (max 100 chars).
+        from_name: Default sender name on campaigns (e.g. 'Marketing Team'). Max 100 chars.
+        from_email: Default sender email. Must be on a verified sending domain.
+        subject: Default subject line for new campaigns. Max 150 chars.
+        language: Default language code (e.g. 'en', 'fr', 'es'). ISO 639-1 two-letter code.
+        company: Legal company name displayed in email footer (required by CAN-SPAM).
+        address1: Primary postal address line shown in email footer.
+        city: City of the postal address.
+        state: State or region of the postal address.
+        zip: Postal/ZIP code.
+        country: Two-letter ISO country code (e.g. 'US', 'FR', 'GB').
+        permission_reminder: Sentence shown at the bottom of every email explaining why
+            subscribers receive it (required by CAN-SPAM).
+        email_type_option: If true, lets subscribers choose plaintext vs. HTML emails. Default false.
+        address2: Optional secondary postal address line.
+        phone: Optional contact phone number shown in the footer.
+
+    Returns:
+        JSON with id (new list_id, save for subsequent calls), name, member_count (0 at creation),
+        date_created, subscribe_url_short.
+    """
+    if (guard := _guard_write(action="create audience", name=name, from_email=from_email)):
+        return guard
+    contact: dict = {
+        "company": company,
+        "address1": address1,
+        "city": city,
+        "state": state,
+        "zip": zip,
+        "country": country,
+    }
+    if address2:
+        contact["address2"] = address2
+    if phone:
+        contact["phone"] = phone
+    body = {
+        "name": name,
+        "contact": contact,
+        "permission_reminder": permission_reminder,
+        "campaign_defaults": {
+            "from_name": from_name,
+            "from_email": from_email,
+            "subject": subject,
+            "language": language,
+        },
+        "email_type_option": email_type_option,
+    }
+    data = mc_request("/lists", body=body, method="POST")
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    return json.dumps({
+        "id": data.get("id"),
+        "name": data.get("name"),
+        "member_count": data.get("stats", {}).get("member_count", 0),
+        "date_created": data.get("date_created"),
+        "subscribe_url_short": data.get("subscribe_url_short"),
+    }, indent=2)
+
+
+@mcp.tool()
+def delete_audience(list_id: str) -> str:
+    """Permanently delete an audience and all its members, segments, campaigns, and stats. Irreversible.
+
+    Side effect: removes every member of the audience and all historical data tied to it.
+    Cannot be undone via the API. Use update_audience to rename or archive-like changes instead.
+    Use list_audience_members to back up members first if needed.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+    Returns 404 error if list_id does not exist.
+
+    Args:
+        list_id: Audience/list ID to delete (10-char alphanumeric, e.g. 'abc123def4').
+            Obtain from list_audiences. Double-check before calling — deletion is permanent.
+
+    Returns:
+        JSON with status ('deleted') and list_id on success, or error object on failure.
+    """
+    if (guard := _guard_write(action="delete audience", list_id=list_id)):
+        return guard
+    result = mc_request(f"/lists/{list_id}", method="DELETE")
+    if isinstance(result, dict) and "error" in result:
+        return json.dumps(result, indent=2)
+    return json.dumps({"status": "deleted", "list_id": list_id}, indent=2)
+
+
 # --- Write Tools: Campaigns ---
 
 @mcp.tool()
-def create_campaign(list_id: str, subject_line: str, title: Optional[str] = None, preview_text: Optional[str] = None, from_name: Optional[str] = None, reply_to: Optional[str] = None, segment_id: Optional[str] = None) -> str:
-    """Create a new regular email campaign in draft status, optionally targeting a specific segment.
+def create_campaign(list_id: str, subject_line: str, title: Optional[str] = None, preview_text: Optional[str] = None, from_name: Optional[str] = None, reply_to: Optional[str] = None, segment_id: Optional[str] = None, campaign_type: str = "regular", variate_settings_json: Optional[str] = None) -> str:
+    """Create a new email campaign in draft status, with optional segment targeting or A/B variate testing.
 
     Typical workflow: create_campaign -> set_campaign_content (add HTML body) -> send_test_email
     (preview) -> send_campaign or schedule_campaign (deliver). The campaign is created in 'save'
     (draft) status and cannot be sent until content is set. Use replicate_campaign instead to
     clone an existing campaign.
 
+    For A/B testing, set campaign_type='variate' and pass variate_settings_json describing the
+    test. Mailchimp will send variants to a sample of recipients, then auto-pick a winner based
+    on winner_criteria and send it to the remaining audience after wait_time.
+
     Authenticated via API key. Subject to Mailchimp API rate limits (max 10 concurrent requests). Respects read-only and dry-run modes.
 
     Args:
         list_id: The audience/list ID to send to (e.g. 'abc123def4'). Obtain from list_audiences.
         subject_line: Subject line recipients see in their inbox. Keep under 150 chars.
+            For variate campaigns testing subject lines, this is the default/fallback.
         title: Internal title for organizing in Mailchimp dashboard. Defaults to subject_line
             if omitted.
         preview_text: Preheader text shown after the subject line in inbox. Keep under 200 chars.
@@ -924,17 +1027,30 @@ def create_campaign(list_id: str, subject_line: str, title: Optional[str] = None
         reply_to: Reply-to email address. Must be a verified domain. Falls back to audience default.
         segment_id: Saved segment ID to restrict recipients. Only members matching this segment
             receive the email. Obtain from list_segments. Omit to send to the full audience.
+        campaign_type: 'regular' (default) for a standard campaign, or 'variate' for an A/B test.
+            'plaintext', 'rss', and 'absplit' (legacy A/B) are also accepted but rarely used.
+        variate_settings_json: Required when campaign_type='variate'. JSON string with keys:
+            winner_criteria ('opens' | 'clicks' | 'manual' | 'total_revenue'), test_size (10-100,
+            percent of audience sampled), wait_time (minutes before picking winner), and one of
+            subject_lines (list of 2-8 strings), from_names (list of 2-8), reply_to_addresses
+            (list of 2-8), send_times (list of 2-8 ISO datetimes), or contents (list of 2-8
+            HTML strings). Example:
+            '{"winner_criteria": "opens", "test_size": 20, "wait_time": 1440,
+              "subject_lines": ["Spring Sale 20% off", "Last chance: 20% off Spring"]}'
 
     Returns:
         JSON with fields: id (string, the new campaign ID for use with set_campaign_content,
         send_campaign, etc.), status ('save'), title, subject_line, web_id (int, for Mailchimp
-        web UI link). Returns error if list_id is invalid.
+        web UI link), type. Returns error if list_id is invalid, variate_settings_json is
+        malformed, or variate settings violate Mailchimp constraints.
 
     Example:
-        create_campaign(list_id="abc123", subject_line="Spring Sale", preview_text="20% off everything") -> {"id": "def456", "status": "save", "title": "Spring Sale", ...}
+        create_campaign(list_id="abc123", subject_line="Spring Sale", preview_text="20% off") -> {"id": "def456", "status": "save", "type": "regular", ...}
     """
-    if (guard := _guard_write(action="create campaign draft", list_id=list_id, subject_line=subject_line)):
+    if (guard := _guard_write(action="create campaign draft", list_id=list_id, subject_line=subject_line, campaign_type=campaign_type)):
         return guard
+    if campaign_type == "variate" and not variate_settings_json:
+        return json.dumps({"error": "variate_settings_json is required when campaign_type='variate'"}, indent=2)
     settings: dict = {"subject_line": subject_line, "title": title or subject_line}
     if preview_text:
         settings["preview_text"] = preview_text
@@ -945,15 +1061,23 @@ def create_campaign(list_id: str, subject_line: str, title: Optional[str] = None
     recipients: dict = {"list_id": list_id}
     if segment_id:
         recipients["segment_opts"] = {"saved_segment_id": int(segment_id)}
-    body = {
-        "type": "regular",
+    body: dict = {
+        "type": campaign_type,
         "recipients": recipients,
         "settings": settings,
     }
+    if variate_settings_json:
+        try:
+            body["variate_settings"] = json.loads(variate_settings_json)
+        except json.JSONDecodeError as e:
+            return json.dumps({"error": f"Invalid variate_settings_json: {e}"}, indent=2)
     data = mc_request("/campaigns", body=body, method="POST")
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({
         "id": data.get("id"),
         "status": data.get("status"),
+        "type": data.get("type"),
         "title": data.get("settings", {}).get("title"),
         "subject_line": data.get("settings", {}).get("subject_line"),
         "web_id": data.get("web_id"),
@@ -2079,6 +2203,91 @@ def get_domain_performance(campaign_id: str) -> str:
             "unsubs": d.get("unsubs"),
         })
     return json.dumps({"total_items": data.get("total_items"), "domains": domains}, indent=2)
+
+
+@mcp.tool()
+def get_campaign_advice(campaign_id: str) -> str:
+    """Retrieve Mailchimp's automated post-send feedback on a campaign (subject line, content, engagement tips).
+
+    Use to surface algorithmic suggestions Mailchimp makes after looking at how a campaign
+    performed (e.g. 'your open rate is below industry average, try shorter subject lines').
+    Use get_campaign_report for raw metrics. Only works for sent campaigns.
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+    Returns 404 error if campaign_id is invalid. Returns an empty advice array if Mailchimp
+    has no suggestions for the campaign.
+
+    Args:
+        campaign_id: The Mailchimp campaign ID (e.g. 'abc123def4'). Must be a sent campaign.
+
+    Returns:
+        JSON with total_items and advice array. Each entry: type ('positive' | 'negative' |
+        'neutral'), message (string, the advice text).
+    """
+    data = mc_request(f"/reports/{campaign_id}/advice")
+    advice = []
+    for a in data.get("advice", []):
+        advice.append({"type": a.get("type"), "message": a.get("message")})
+    return json.dumps({"total_items": data.get("total_items"), "advice": advice}, indent=2)
+
+
+@mcp.tool()
+def get_campaign_locations(campaign_id: str, count: int = 20, offset: int = 0) -> str:
+    """Retrieve geographic open data for a sent campaign, broken down by country and region.
+
+    Use to map where opens happened — useful for region-targeted follow-ups, timezone-aware
+    sending, or audit reports. Aggregated from IP geolocation at open time. Use
+    get_domain_performance for per-provider stats instead. Only works for sent campaigns.
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+
+    Args:
+        campaign_id: The Mailchimp campaign ID (e.g. 'abc123def4'). Must be a sent campaign.
+        count: Number of locations to return (1-1000, default 20).
+        offset: Pagination offset. Use when total_items exceeds count.
+
+    Returns:
+        JSON with total_items and locations array. Each entry: country_code (ISO 2-letter,
+        e.g. 'US'), region (string, state/province name or code), region_name (full name),
+        opens (int, opens from that region).
+    """
+    data = mc_request(f"/reports/{campaign_id}/locations", params={"count": count, "offset": offset})
+    locations = []
+    for loc in data.get("locations", []):
+        locations.append({
+            "country_code": loc.get("country_code"),
+            "region": loc.get("region"),
+            "region_name": loc.get("region_name"),
+            "opens": loc.get("opens"),
+        })
+    return json.dumps({"total_items": data.get("total_items"), "locations": locations}, indent=2)
+
+
+@mcp.tool()
+def get_eepurl_activity(campaign_id: str) -> str:
+    """Retrieve social sharing stats for a campaign's eepurl (Mailchimp's short-URL share link).
+
+    Use to measure how much the campaign was shared on Twitter/Facebook/etc. via the
+    'Share this' link Mailchimp generates. Use get_campaign_click_details for in-email link
+    clicks instead. Only works for sent campaigns where eepurl tracking is enabled.
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+
+    Args:
+        campaign_id: The Mailchimp campaign ID (e.g. 'abc123def4'). Must be a sent campaign.
+
+    Returns:
+        JSON with eepurl (the short URL), twitter (object with statuses, first_status,
+        last_status, replies, impressions, retweets), facebook (object with likes, recipient_likes,
+        unique_likes), referrers array (list of {referrer, clicks, first_click, last_click}).
+    """
+    data = mc_request(f"/reports/{campaign_id}/eepurl")
+    return json.dumps({
+        "eepurl": data.get("eepurl"),
+        "twitter": data.get("twitter"),
+        "facebook": data.get("facebook"),
+        "referrers": data.get("clicks", {}).get("referrer_clicks", []),
+    }, indent=2)
 
 
 @mcp.tool()

--- a/tests/test_tools_smoke.py
+++ b/tests/test_tools_smoke.py
@@ -140,3 +140,166 @@ class TestMembers:
         body = calls[0]["body"]
         assert body["tags"] == ["VIP", "Newsletter"]
         assert body["merge_fields"]["FNAME"] == "Alice"
+
+
+class TestAudienceCRUD:
+    def _valid_payload(self) -> dict:
+        return {
+            "name": "New Audience",
+            "from_name": "Damien",
+            "from_email": "damien@tilman.marketing",
+            "subject": "Welcome",
+            "language": "en",
+            "company": "Tilman Marketing",
+            "address1": "1 Main St",
+            "city": "Paris",
+            "state": "IDF",
+            "zip": "75001",
+            "country": "FR",
+            "permission_reminder": "You signed up at tilman.marketing.",
+        }
+
+    def test_create_audience_sends_required_fields(self, mock_mc_request) -> None:
+        calls = mock_mc_request(
+            {
+                "id": "new_list",
+                "name": "New Audience",
+                "stats": {"member_count": 0},
+                "date_created": "2026-05-16T00:00:00Z",
+                "subscribe_url_short": "http://eepurl.com/x",
+            }
+        )
+        result = server.create_audience(**self._valid_payload())
+        payload = json.loads(result)
+
+        assert payload["id"] == "new_list"
+        assert payload["member_count"] == 0
+
+        body = calls[0]["body"]
+        assert calls[0]["endpoint"] == "/lists"
+        assert calls[0]["method"] == "POST"
+        assert body["name"] == "New Audience"
+        assert body["contact"]["country"] == "FR"
+        assert body["campaign_defaults"]["from_email"] == "damien@tilman.marketing"
+        assert body["email_type_option"] is False
+
+    def test_create_audience_propagates_api_error(self, mock_mc_request) -> None:
+        mock_mc_request({"error": "Invalid Resource", "detail": "address1 is required", "status": 400})
+        result = server.create_audience(**self._valid_payload())
+        payload = json.loads(result)
+        assert payload["error"] == "Invalid Resource"
+
+    def test_delete_audience(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"status": "success"})
+        result = server.delete_audience(list_id="list_a")
+        payload = json.loads(result)
+        assert payload == {"status": "deleted", "list_id": "list_a"}
+        assert calls[0]["method"] == "DELETE"
+        assert calls[0]["endpoint"] == "/lists/list_a"
+
+
+class TestVariateCampaigns:
+    def test_regular_campaign_default_type(self, mock_mc_request) -> None:
+        calls = mock_mc_request(
+            {"id": "cam1", "status": "save", "type": "regular", "settings": {"title": "Hi"}, "web_id": 1}
+        )
+        server.create_campaign(list_id="abc", subject_line="Hi")
+        body = calls[0]["body"]
+        assert body["type"] == "regular"
+        assert "variate_settings" not in body
+
+    def test_variate_campaign_parses_settings(self, mock_mc_request) -> None:
+        calls = mock_mc_request(
+            {"id": "cam2", "status": "save", "type": "variate", "settings": {"title": "AB"}, "web_id": 2}
+        )
+        variate = json.dumps(
+            {
+                "winner_criteria": "opens",
+                "test_size": 20,
+                "wait_time": 1440,
+                "subject_lines": ["Spring Sale 20% off", "Last chance: 20% off Spring"],
+            }
+        )
+        result = server.create_campaign(
+            list_id="abc",
+            subject_line="Spring Sale 20% off",
+            campaign_type="variate",
+            variate_settings_json=variate,
+        )
+        payload = json.loads(result)
+        assert payload["type"] == "variate"
+
+        body = calls[0]["body"]
+        assert body["type"] == "variate"
+        assert body["variate_settings"]["winner_criteria"] == "opens"
+        assert body["variate_settings"]["subject_lines"] == [
+            "Spring Sale 20% off",
+            "Last chance: 20% off Spring",
+        ]
+
+    def test_variate_requires_settings(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"should": "not-be-called"})
+        result = server.create_campaign(
+            list_id="abc",
+            subject_line="Hi",
+            campaign_type="variate",
+        )
+        payload = json.loads(result)
+        assert "error" in payload
+        assert "variate_settings_json is required" in payload["error"]
+        assert calls == []
+
+    def test_variate_rejects_invalid_json(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"should": "not-be-called"})
+        result = server.create_campaign(
+            list_id="abc",
+            subject_line="Hi",
+            campaign_type="variate",
+            variate_settings_json="{not valid json",
+        )
+        payload = json.loads(result)
+        assert "Invalid variate_settings_json" in payload["error"]
+        assert calls == []
+
+
+class TestReportsExtras:
+    def test_get_campaign_advice(self, mock_mc_request) -> None:
+        mock_mc_request(
+            {
+                "total_items": 2,
+                "advice": [
+                    {"type": "negative", "message": "Your open rate is below industry average."},
+                    {"type": "positive", "message": "Click rate is strong."},
+                ],
+            }
+        )
+        payload = json.loads(server.get_campaign_advice(campaign_id="cam_1"))
+        assert payload["total_items"] == 2
+        assert payload["advice"][0]["type"] == "negative"
+
+    def test_get_campaign_locations_pagination(self, mock_mc_request) -> None:
+        calls = mock_mc_request(
+            {
+                "total_items": 1,
+                "locations": [
+                    {"country_code": "US", "region": "CA", "region_name": "California", "opens": 42},
+                ],
+            }
+        )
+        payload = json.loads(server.get_campaign_locations(campaign_id="cam_1", count=50))
+        assert payload["locations"][0]["country_code"] == "US"
+        assert calls[0]["params"]["count"] == 50
+
+    def test_get_eepurl_activity(self, mock_mc_request) -> None:
+        mock_mc_request(
+            {
+                "eepurl": "http://eepurl.com/xyz",
+                "twitter": {"statuses": 12, "impressions": 5000},
+                "facebook": {"likes": 30, "unique_likes": 28},
+                "clicks": {"referrer_clicks": [{"referrer": "t.co", "clicks": 12}]},
+            }
+        )
+        payload = json.loads(server.get_eepurl_activity(campaign_id="cam_1"))
+        assert payload["eepurl"] == "http://eepurl.com/xyz"
+        assert payload["twitter"]["impressions"] == 5000
+        assert payload["referrers"][0]["referrer"] == "t.co"


### PR DESCRIPTION
- create_audience and delete_audience for full list lifecycle management (closes #9)
- get_campaign_advice, get_campaign_locations, get_eepurl_activity for post-send feedback, geographic open data, and social sharing stats (closes #13)
- create_campaign extended with campaign_type and variate_settings_json to support A/B (variate) campaigns; variate payload is validated before dispatch and obvious misuses (missing settings, invalid JSON) return clear errors (closes #7)
- 10 new tests covering the additions, with coverage of the variate failure paths
- Version bumped to 0.3.0; tool count now 87 across README, glama.json and pyproject.toml