### PR TITLE
Release v0.4.0: landing page CRUD, member notes, template metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05
+
+### Added
+- **Landing page lifecycle**: `create_landing_page`, `update_landing_page`,
+  `delete_landing_page`, `publish_landing_page`, `unpublish_landing_page` — full
+  CRUD plus publish/unpublish actions on top of the existing read tools
+  (closes #11).
+- **Member notes (CRM-style)**: `list_member_notes`, `add_member_note`,
+  `update_member_note`, `delete_member_note` for internal annotations on
+  contacts that are never sent to them (closes #8).
+- **`get_template`**: metadata-only template lookup (name, type, dates,
+  thumbnail, share URL) complementing the existing `get_template_default_content`
+  for HTML retrieval (closes #10).
+- Smoke tests for the ten new tools, including subscriber-hash routing for
+  member notes and the JSON-shape contracts for landing page actions.
+
+### Changed
+- Tool count bumped to **97** (was 87) — README, `glama.json`, and
+  `pyproject.toml` descriptions updated accordingly.
+
 ## [0.3.0] - 2026-05
 
 ### Added
@@ -88,7 +108,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   landing pages, e-commerce, and batch operations.
 - MIT license, Python 3.10+ support, MCP-compatible via FastMCP.
 
-[Unreleased]: https://github.com/damientilman/mailchimp-mcp-server/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/damientilman/mailchimp-mcp-server/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/damientilman/mailchimp-mcp-server/releases/tag/v0.4.0
 [0.3.0]: https://github.com/damientilman/mailchimp-mcp-server/releases/tag/v0.3.0
 [0.2.1]: https://github.com/damientilman/mailchimp-mcp-server/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/damientilman/mailchimp-mcp-server/releases/tag/v0.2.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![MCP](https://img.shields.io/badge/MCP-compatible-green.svg)](https://modelcontextprotocol.io)
 
-The most complete [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/) — **87 tools** to query and manage your Mailchimp account from any MCP-compatible client, with A/B campaign support, geographic reporting, and read-only / dry-run safety modes.
+The most complete [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/) — **97 tools** to query and manage your Mailchimp account from any MCP-compatible client, with A/B campaign support, geographic reporting, full landing-page lifecycle, CRM-style member notes, and read-only / dry-run safety modes.
 
 Uses the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/api/) via [`requests`](https://pypi.org/project/requests/). Not based on the official [mailchimp-marketing-python](https://github.com/mailchimp/mailchimp-marketing-python) client. I hit too many issues with it so I went with raw HTTP calls instead.
 
@@ -240,6 +240,7 @@ Replace `mcp-cli` with your client's binary name. For read-only mode, add
 | `get_member_activity` | Activity history of a specific contact |
 | `get_member_tags` | All tags assigned to a contact |
 | `get_member_events` | Custom events for a contact |
+| `list_member_notes` | List CRM-style internal notes attached to a contact |
 
 ### Members (write)
 
@@ -250,6 +251,9 @@ Replace `mcp-cli` with your client's binary name. For read-only mode, add
 | `unsubscribe_member` | Unsubscribe a contact |
 | `delete_member` | Permanently delete a contact |
 | `tag_member` | Add or remove tags from a contact |
+| `add_member_note` | Attach a CRM-style internal note to a contact |
+| `update_member_note` | Update the text of an existing member note |
+| `delete_member_note` | Delete a member note |
 
 ### Audiences (write)
 
@@ -316,6 +320,7 @@ Replace `mcp-cli` with your client's binary name. For read-only mode, add
 | Tool | Description |
 |---|---|
 | `list_templates` | List available email templates |
+| `get_template` | Get template metadata (name, type, dates, thumbnail) |
 | `get_template_default_content` | Get template HTML content |
 | `create_template` | Create a new email template |
 | `update_template` | Update template name or HTML |
@@ -327,6 +332,11 @@ Replace `mcp-cli` with your client's binary name. For read-only mode, add
 |---|---|
 | `list_landing_pages` | List all landing pages |
 | `get_landing_page` | Get details of a landing page |
+| `create_landing_page` | Create a new landing page from a template |
+| `update_landing_page` | Update settings of an existing landing page |
+| `delete_landing_page` | Permanently delete a landing page |
+| `publish_landing_page` | Publish a landing page to its public URL |
+| `unpublish_landing_page` | Take a published landing page offline |
 
 ### E-commerce
 

--- a/glama.json
+++ b/glama.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "mailchimp-mcp",
-  "description": "MCP server for the Mailchimp Marketing API. 87 tools for managing campaigns, audiences, members, templates, segments, automations, reports, e-commerce, A/B testing, and more.",
+  "description": "MCP server for the Mailchimp Marketing API. 97 tools for managing campaigns, audiences, members, templates, segments, automations, reports, e-commerce, A/B testing, landing pages, CRM notes, and more.",
   "author": {
     "name": "Damien Tilman",
     "url": "https://github.com/damientilman"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mailchimp-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for the Mailchimp Marketing API — access campaigns, audiences, reports, and more from any MCP-compatible client."
 readme = "README.md"
 license = "MIT"

--- a/src/mailchimp_mcp_server/__init__.py
+++ b/src/mailchimp_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Mailchimp MCP Server — access Mailchimp data via the Model Context Protocol."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/src/mailchimp_mcp_server/server.py
+++ b/src/mailchimp_mcp_server/server.py
@@ -511,6 +511,43 @@ def get_template_default_content(template_id: str) -> str:
 
 
 @mcp.tool()
+def get_template(template_id: str) -> str:
+    """Retrieve metadata for a template (name, type, dates, folder, thumbnail) without its HTML content.
+
+    Use to inspect a template's settings or verify it exists before referencing it elsewhere.
+    Use get_template_default_content to fetch the actual HTML body. Use list_templates to browse
+    and discover template IDs.
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+    Returns 404 error if template_id is invalid.
+
+    Args:
+        template_id: Template ID (numeric string, e.g. '12345'). Obtain from list_templates.
+
+    Returns:
+        JSON with id, name, type ('user' | 'base' | 'gallery'), drag_and_drop (bool),
+        date_created, date_edited, created_by, edited_by, active (bool), folder_id, thumbnail,
+        share_url, category.
+    """
+    data = mc_request(f"/templates/{template_id}")
+    return json.dumps({
+        "id": data.get("id"),
+        "name": data.get("name"),
+        "type": data.get("type"),
+        "drag_and_drop": data.get("drag_and_drop"),
+        "date_created": data.get("date_created"),
+        "date_edited": data.get("date_edited"),
+        "created_by": data.get("created_by"),
+        "edited_by": data.get("edited_by"),
+        "active": data.get("active"),
+        "folder_id": data.get("folder_id"),
+        "thumbnail": data.get("thumbnail"),
+        "share_url": data.get("share_url"),
+        "category": data.get("category"),
+    }, indent=2)
+
+
+@mcp.tool()
 def create_template(name: str, html: str, folder_id: Optional[str] = None) -> str:
     """Create a new reusable email template from HTML content.
 
@@ -2444,6 +2481,154 @@ def get_member_events(list_id: str, email_address: str, count: int = 20) -> str:
     return json.dumps({"email_address": email_address, "total_items": data.get("total_items"), "events": events}, indent=2)
 
 
+# --- Read/Write Tools: Member Notes ---
+
+@mcp.tool()
+def list_member_notes(list_id: str, email_address: str, count: int = 20, offset: int = 0) -> str:
+    """List CRM-style notes attached to a member by team members (not visible to the contact).
+
+    Notes are internal annotations like "Called about pricing" or "VIP customer". They are not
+    sent to the contact and do not affect deliverability. Use add_member_note to create one,
+    update_member_note to edit, delete_member_note to remove.
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+    Returns 404 error if the member does not exist.
+
+    Args:
+        list_id: Audience/list ID (10-char alphanumeric, e.g. 'abc123def4'). Obtain from list_audiences.
+        email_address: Email of the member whose notes to list. Must exist in the audience.
+        count: Number of notes to return (1-1000, default 20).
+        offset: Pagination offset. Use when total_items exceeds count.
+
+    Returns:
+        JSON with email_address, total_items, and notes array. Each note: id (use as note_id),
+        note (string, the text), created_at, created_by, updated_at.
+    """
+    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    data = mc_request(
+        f"/lists/{list_id}/members/{subscriber_hash}/notes",
+        params={"count": count, "offset": offset},
+    )
+    notes = []
+    for n in data.get("notes", []):
+        notes.append({
+            "id": n.get("id"),
+            "note": n.get("note"),
+            "created_at": n.get("created_at"),
+            "created_by": n.get("created_by"),
+            "updated_at": n.get("updated_at"),
+        })
+    return json.dumps({
+        "email_address": email_address,
+        "total_items": data.get("total_items"),
+        "notes": notes,
+    }, indent=2)
+
+
+@mcp.tool()
+def add_member_note(list_id: str, email_address: str, note: str) -> str:
+    """Add a CRM-style internal note to a member. Not sent to the contact.
+
+    Useful for sales/support context, e.g. "Asked for discount on annual plan", "Out of office
+    until June 1st". Use update_member_note to edit an existing note instead of adding another.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+    Returns 404 if the member does not exist; returns 400 if note text exceeds 1000 chars.
+
+    Args:
+        list_id: Audience/list ID. Obtain from list_audiences.
+        email_address: Email of the member to attach the note to. Must exist in the audience.
+        note: Note text (max 1000 chars). Plain text; markdown is not rendered in the Mailchimp UI.
+
+    Returns:
+        JSON with id (use as note_id), email_address, note, created_at, created_by.
+    """
+    if (guard := _guard_write(action="add member note", list_id=list_id, email_address=email_address)):
+        return guard
+    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    data = mc_request(
+        f"/lists/{list_id}/members/{subscriber_hash}/notes",
+        body={"note": note},
+        method="POST",
+    )
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    return json.dumps({
+        "id": data.get("id"),
+        "email_address": email_address,
+        "note": data.get("note"),
+        "created_at": data.get("created_at"),
+        "created_by": data.get("created_by"),
+    }, indent=2)
+
+
+@mcp.tool()
+def update_member_note(list_id: str, email_address: str, note_id: str, note: str) -> str:
+    """Update the text of an existing member note. Replaces the entire note body.
+
+    Use list_member_notes to find note_ids. Use add_member_note instead to create a new note
+    rather than overwriting; use delete_member_note to remove a note.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+    Returns 404 if the note or member does not exist.
+
+    Args:
+        list_id: Audience/list ID. Obtain from list_audiences.
+        email_address: Email of the member who owns the note.
+        note_id: Note ID to update. Obtain from list_member_notes.
+        note: New note text (max 1000 chars). Replaces the previous text entirely.
+
+    Returns:
+        JSON with id, email_address, note (new value), updated_at.
+    """
+    if (guard := _guard_write(action="update member note", list_id=list_id, email_address=email_address, note_id=note_id)):
+        return guard
+    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    data = mc_request(
+        f"/lists/{list_id}/members/{subscriber_hash}/notes/{note_id}",
+        body={"note": note},
+        method="PATCH",
+    )
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    return json.dumps({
+        "id": data.get("id"),
+        "email_address": email_address,
+        "note": data.get("note"),
+        "updated_at": data.get("updated_at"),
+    }, indent=2)
+
+
+@mcp.tool()
+def delete_member_note(list_id: str, email_address: str, note_id: str) -> str:
+    """Permanently delete a note attached to a member. Cannot be undone.
+
+    Use list_member_notes to find note_ids before calling. Does not affect the member itself,
+    only the note.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+    Returns 404 if the note or member does not exist.
+
+    Args:
+        list_id: Audience/list ID. Obtain from list_audiences.
+        email_address: Email of the member who owns the note.
+        note_id: Note ID to delete. Obtain from list_member_notes.
+
+    Returns:
+        JSON with status ('deleted'), email_address, note_id on success.
+    """
+    if (guard := _guard_write(action="delete member note", list_id=list_id, email_address=email_address, note_id=note_id)):
+        return guard
+    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    result = mc_request(
+        f"/lists/{list_id}/members/{subscriber_hash}/notes/{note_id}",
+        method="DELETE",
+    )
+    if isinstance(result, dict) and "error" in result:
+        return json.dumps(result, indent=2)
+    return json.dumps({"status": "deleted", "email_address": email_address, "note_id": note_id}, indent=2)
+
+
 # --- Read/Write Tools: Automations (granular) ---
 
 @mcp.tool()
@@ -2619,6 +2804,187 @@ def get_landing_page(page_id: str) -> str:
         "list_id": data.get("list_id"),
         "tracking": data.get("tracking"),
     }, indent=2)
+
+
+# --- Write Tools: Landing Pages ---
+
+@mcp.tool()
+def create_landing_page(name: str, title: str, list_id: str, template_id: str, store_id: Optional[str] = None, description: Optional[str] = None, tracking_opens: bool = True, tracking_clicks: bool = True) -> str:
+    """Create a new landing page in draft status from a template, optionally linked to a store.
+
+    The page is created unpublished. Use update_landing_page to edit settings or
+    publish_landing_page to make it live at its public URL. Use list_landing_pages or
+    get_landing_page to inspect existing pages.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+    Returns 400 error if template_id is invalid or list_id does not exist.
+
+    Args:
+        name: Internal name for the page (shown in the Mailchimp dashboard, not to visitors).
+        title: Browser tab title (shown in the page's HTML <title>).
+        list_id: Audience ID this page collects signups for (e.g. 'abc123def4').
+            Obtain from list_audiences.
+        template_id: Template ID to base the page on. Obtain from list_templates.
+        store_id: Optional e-commerce store ID to link the page to. Obtain from
+            list_ecommerce_stores.
+        description: Optional internal description.
+        tracking_opens: Track view-opens analytics. Default true.
+        tracking_clicks: Track link clicks analytics. Default true.
+
+    Returns:
+        JSON with id (use as page_id for subsequent calls), name, title, status ('unpublished'),
+        url (null until published), created_at, list_id.
+    """
+    if (guard := _guard_write(action="create landing page", name=name, list_id=list_id)):
+        return guard
+    body: dict = {
+        "name": name,
+        "title": title,
+        "list_id": list_id,
+        "template": {"id": int(template_id)},
+        "tracking": {"opens": tracking_opens, "clicks": tracking_clicks},
+    }
+    if store_id:
+        body["store_id"] = store_id
+    if description:
+        body["description"] = description
+    data = mc_request("/landing-pages", body=body, method="POST")
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    return json.dumps({
+        "id": data.get("id"),
+        "name": data.get("name"),
+        "title": data.get("title"),
+        "status": data.get("status"),
+        "url": data.get("url"),
+        "created_at": data.get("created_at"),
+        "list_id": data.get("list_id"),
+    }, indent=2)
+
+
+@mcp.tool()
+def update_landing_page(page_id: str, name: Optional[str] = None, title: Optional[str] = None, description: Optional[str] = None, tracking_opens: Optional[bool] = None, tracking_clicks: Optional[bool] = None) -> str:
+    """Update settings of an existing landing page. Only provided fields are changed.
+
+    Cannot change list_id or template after creation; create a new page instead. Use
+    publish_landing_page / unpublish_landing_page to change live status. Use get_landing_page
+    to inspect current settings before updating.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+    Returns 404 error if page_id is invalid.
+
+    Args:
+        page_id: Landing page ID. Obtain from list_landing_pages.
+        name: New internal name.
+        title: New browser tab title.
+        description: New internal description.
+        tracking_opens: Toggle open tracking on/off.
+        tracking_clicks: Toggle click tracking on/off.
+
+    Returns:
+        JSON with id, name, title, status, url, updated_at, list_id.
+    """
+    if (guard := _guard_write(action="update landing page", page_id=page_id)):
+        return guard
+    body: dict = {}
+    if name is not None:
+        body["name"] = name
+    if title is not None:
+        body["title"] = title
+    if description is not None:
+        body["description"] = description
+    tracking: dict = {}
+    if tracking_opens is not None:
+        tracking["opens"] = tracking_opens
+    if tracking_clicks is not None:
+        tracking["clicks"] = tracking_clicks
+    if tracking:
+        body["tracking"] = tracking
+    data = mc_request(f"/landing-pages/{page_id}", body=body, method="PATCH")
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    return json.dumps({
+        "id": data.get("id"),
+        "name": data.get("name"),
+        "title": data.get("title"),
+        "status": data.get("status"),
+        "url": data.get("url"),
+        "updated_at": data.get("updated_at"),
+        "list_id": data.get("list_id"),
+    }, indent=2)
+
+
+@mcp.tool()
+def delete_landing_page(page_id: str) -> str:
+    """Permanently delete a landing page. Cannot be undone.
+
+    Side effect: the page becomes inaccessible at its public URL immediately. Past visit
+    analytics remain in Mailchimp's reports area but the page itself is gone. Use
+    unpublish_landing_page if you only want to take it offline temporarily.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+    Returns 404 error if page_id is invalid.
+
+    Args:
+        page_id: Landing page ID to delete. Obtain from list_landing_pages.
+
+    Returns:
+        JSON with status ('deleted') and page_id on success.
+    """
+    if (guard := _guard_write(action="delete landing page", page_id=page_id)):
+        return guard
+    result = mc_request(f"/landing-pages/{page_id}", method="DELETE")
+    if isinstance(result, dict) and "error" in result:
+        return json.dumps(result, indent=2)
+    return json.dumps({"status": "deleted", "page_id": page_id}, indent=2)
+
+
+@mcp.tool()
+def publish_landing_page(page_id: str) -> str:
+    """Publish a landing page, making it live at its public URL.
+
+    Idempotent on already-published pages. Use unpublish_landing_page to take a page offline.
+    Use get_landing_page to confirm the live URL after publishing.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+    Returns 400 if the page is missing required content; returns 404 if page_id is invalid.
+
+    Args:
+        page_id: Landing page ID to publish. Obtain from list_landing_pages.
+
+    Returns:
+        JSON with status ('published') and page_id on success.
+    """
+    if (guard := _guard_write(action="publish landing page", page_id=page_id)):
+        return guard
+    result = mc_request(f"/landing-pages/{page_id}/actions/publish", method="POST")
+    if isinstance(result, dict) and "error" in result:
+        return json.dumps(result, indent=2)
+    return json.dumps({"status": "published", "page_id": page_id}, indent=2)
+
+
+@mcp.tool()
+def unpublish_landing_page(page_id: str) -> str:
+    """Take a published landing page offline. The public URL stops serving the page.
+
+    Reversible — re-publish with publish_landing_page. Use delete_landing_page for permanent
+    removal instead.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+    Returns 404 error if page_id is invalid.
+
+    Args:
+        page_id: Landing page ID to unpublish. Obtain from list_landing_pages.
+
+    Returns:
+        JSON with status ('unpublished') and page_id on success.
+    """
+    if (guard := _guard_write(action="unpublish landing page", page_id=page_id)):
+        return guard
+    result = mc_request(f"/landing-pages/{page_id}/actions/unpublish", method="POST")
+    if isinstance(result, dict) and "error" in result:
+        return json.dumps(result, indent=2)
+    return json.dumps({"status": "unpublished", "page_id": page_id}, indent=2)
 
 
 # --- Read Tools: E-commerce ---

--- a/tests/test_tools_smoke.py
+++ b/tests/test_tools_smoke.py
@@ -303,3 +303,123 @@ class TestReportsExtras:
         assert payload["eepurl"] == "http://eepurl.com/xyz"
         assert payload["twitter"]["impressions"] == 5000
         assert payload["referrers"][0]["referrer"] == "t.co"
+
+
+class TestTemplatesMetadata:
+    def test_get_template(self, mock_mc_request) -> None:
+        mock_mc_request(
+            {
+                "id": 42,
+                "name": "Welcome Series",
+                "type": "user",
+                "drag_and_drop": True,
+                "date_created": "2026-01-01T00:00:00Z",
+                "date_edited": "2026-02-01T00:00:00Z",
+                "active": True,
+                "thumbnail": "https://example.com/t.png",
+                "share_url": "https://us1.admin.mailchimp.com/...",
+            }
+        )
+        payload = json.loads(server.get_template(template_id="42"))
+        assert payload["id"] == 42
+        assert payload["name"] == "Welcome Series"
+        assert payload["type"] == "user"
+        assert payload["drag_and_drop"] is True
+
+
+class TestLandingPageCRUD:
+    def test_create_landing_page_sends_template_id_as_int(self, mock_mc_request) -> None:
+        calls = mock_mc_request(
+            {
+                "id": "page_1",
+                "name": "Promo Page",
+                "title": "Spring promo",
+                "status": "unpublished",
+                "url": None,
+                "created_at": "2026-05-16T00:00:00Z",
+                "list_id": "abc",
+            }
+        )
+        server.create_landing_page(
+            name="Promo Page",
+            title="Spring promo",
+            list_id="abc",
+            template_id="42",
+        )
+        body = calls[0]["body"]
+        assert body["name"] == "Promo Page"
+        assert body["list_id"] == "abc"
+        assert body["template"] == {"id": 42}
+        assert body["tracking"] == {"opens": True, "clicks": True}
+        assert calls[0]["method"] == "POST"
+
+    def test_update_landing_page_only_sends_provided_fields(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"id": "page_1", "name": "X", "status": "unpublished"})
+        server.update_landing_page(page_id="page_1", title="New title", tracking_clicks=False)
+        body = calls[0]["body"]
+        assert "name" not in body
+        assert body["title"] == "New title"
+        assert body["tracking"] == {"clicks": False}
+        assert calls[0]["method"] == "PATCH"
+
+    def test_delete_landing_page(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"status": "success"})
+        result = server.delete_landing_page(page_id="page_1")
+        payload = json.loads(result)
+        assert payload == {"status": "deleted", "page_id": "page_1"}
+        assert calls[0]["method"] == "DELETE"
+        assert calls[0]["endpoint"] == "/landing-pages/page_1"
+
+    def test_publish_landing_page(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"status": "success"})
+        payload = json.loads(server.publish_landing_page(page_id="page_1"))
+        assert payload == {"status": "published", "page_id": "page_1"}
+        assert calls[0]["endpoint"] == "/landing-pages/page_1/actions/publish"
+        assert calls[0]["method"] == "POST"
+
+    def test_unpublish_landing_page(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"status": "success"})
+        payload = json.loads(server.unpublish_landing_page(page_id="page_1"))
+        assert payload == {"status": "unpublished", "page_id": "page_1"}
+        assert calls[0]["endpoint"] == "/landing-pages/page_1/actions/unpublish"
+
+
+class TestMemberNotesCRUD:
+    EMAIL = "jane@example.com"
+    # MD5("jane@example.com") computed once for assertions below.
+    HASH = "9e26471d35a78862c17e467d87cddedf"
+
+    def test_list_member_notes_uses_md5_hash(self, mock_mc_request) -> None:
+        calls = mock_mc_request(
+            {"total_items": 1, "notes": [{"id": 7, "note": "Asked for discount", "created_at": "2026-05-16T00:00:00Z"}]}
+        )
+        payload = json.loads(server.list_member_notes(list_id="abc", email_address=self.EMAIL))
+        assert payload["total_items"] == 1
+        assert payload["notes"][0]["id"] == 7
+        assert calls[0]["endpoint"] == f"/lists/abc/members/{self.HASH}/notes"
+
+    def test_add_member_note(self, mock_mc_request) -> None:
+        calls = mock_mc_request(
+            {"id": 7, "note": "VIP customer", "created_at": "2026-05-16T00:00:00Z", "created_by": "Damien"}
+        )
+        result = server.add_member_note(list_id="abc", email_address=self.EMAIL, note="VIP customer")
+        payload = json.loads(result)
+        assert payload["id"] == 7
+        assert payload["email_address"] == self.EMAIL
+        assert calls[0]["method"] == "POST"
+        assert calls[0]["body"] == {"note": "VIP customer"}
+        assert calls[0]["endpoint"] == f"/lists/abc/members/{self.HASH}/notes"
+
+    def test_update_member_note(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"id": 7, "note": "Updated", "updated_at": "2026-05-17T00:00:00Z"})
+        server.update_member_note(list_id="abc", email_address=self.EMAIL, note_id="7", note="Updated")
+        assert calls[0]["method"] == "PATCH"
+        assert calls[0]["endpoint"] == f"/lists/abc/members/{self.HASH}/notes/7"
+        assert calls[0]["body"] == {"note": "Updated"}
+
+    def test_delete_member_note(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"status": "success"})
+        payload = json.loads(server.delete_member_note(list_id="abc", email_address=self.EMAIL, note_id="7"))
+        assert payload == {"status": "deleted", "email_address": self.EMAIL, "note_id": "7"}
+        assert calls[0]["method"] == "DELETE"
+        assert calls[0]["endpoint"] == f"/lists/abc/members/{self.HASH}/notes/7"


### PR DESCRIPTION
## Summary

- **Landing page lifecycle** — `create_landing_page`, `update_landing_page`, `delete_landing_page`, `publish_landing_page`, `unpublish_landing_page`. Five new tools that round out landing page coverage beyond the existing read tools.
- **Member notes (CRM-style)** — `list_member_notes`, `add_member_note`, `update_member_note`, `delete_member_note`. Internal annotations on contacts that are never sent to them.
- **Template metadata** — `get_template` for the metadata-only lookup (name, type, dates, thumbnail, share URL), complementing the existing `get_template_default_content` for HTML retrieval.

Tool count: **87 → 97**.

Fully backwards-compatible — no existing signatures changed.

Closes #8, #10, #11.

## Test plan

- [x] `uv run pytest` — 47/47 tests pass in ~0.1s
- [x] `uv run ruff check src/ tests/` — clean
- [x] Smoke tests added for each new tool, including subscriber-hash routing on member notes and JSON-shape contracts on landing page actions
- [ ] Manual sanity check against a real Mailchimp sandbox account (optional)

## Notes for the release

- After merge, tag `v0.4.0` on the merge commit (or the release commit) — the publish workflow will trigger automatically and push the package to PyPI via Trusted Publishers (OIDC).
- CHANGELOG entry added under `[0.4.0]`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbgaDAfLrHxDmXVAW2f8MT)_