### PR TITLE
Release v0.5.0: e-commerce carts, promo rules and codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05
+
+### Added
+- **E-commerce carts CRUD**: `list_store_carts`, `get_store_cart`,
+  `create_store_cart`, `update_store_cart`, `delete_store_cart` — full lifecycle
+  for cart objects, with line items passed as JSON for create/update. Designed
+  to support abandoned-cart recovery workflows where the cart originates in an
+  external system.
+- **E-commerce promo rules CRUD**: `list_promo_rules`, `get_promo_rule`,
+  `create_promo_rule`, `update_promo_rule`, `delete_promo_rule` — define
+  discount mechanics (fixed amount, percentage, or free shipping; targeting
+  per-item, total, or shipping cost).
+- **E-commerce promo codes CRUD**: `list_promo_codes`, `get_promo_code`,
+  `create_promo_code`, `update_promo_code`, `delete_promo_code` — manage the
+  redeemable codes (e.g. `SUMMER20`) attached to a promo rule.
+- 16 new smoke tests covering the additions, including JSON parsing for cart
+  line items and the partial-PATCH paths on every update tool.
+- Closes #19 (partial — the high-value subset specifically called out in the
+  issue is implemented; full CRUD for stores, customers, orders, products, and
+  variants is intentionally deferred because in practice that data is synced
+  from external storefronts).
+
+### Changed
+- Tool count bumped to **112** (was 97) — README, `glama.json`, and
+  `pyproject.toml` descriptions updated accordingly.
+
 ## [0.4.0] - 2026-05
 
 ### Added
@@ -108,7 +134,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   landing pages, e-commerce, and batch operations.
 - MIT license, Python 3.10+ support, MCP-compatible via FastMCP.
 
-[Unreleased]: https://github.com/damientilman/mailchimp-mcp-server/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/damientilman/mailchimp-mcp-server/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/damientilman/mailchimp-mcp-server/releases/tag/v0.5.0
 [0.4.0]: https://github.com/damientilman/mailchimp-mcp-server/releases/tag/v0.4.0
 [0.3.0]: https://github.com/damientilman/mailchimp-mcp-server/releases/tag/v0.3.0
 [0.2.1]: https://github.com/damientilman/mailchimp-mcp-server/compare/v0.2.0...v0.2.1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![MCP](https://img.shields.io/badge/MCP-compatible-green.svg)](https://modelcontextprotocol.io)
 
-The most complete [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/) — **97 tools** to query and manage your Mailchimp account from any MCP-compatible client, with A/B campaign support, geographic reporting, full landing-page lifecycle, CRM-style member notes, and read-only / dry-run safety modes.
+The most complete [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/) — **112 tools** to query and manage your Mailchimp account from any MCP-compatible client, with A/B campaign support, geographic reporting, full landing-page lifecycle, CRM-style member notes, e-commerce carts and promo codes, and read-only / dry-run safety modes.
 
 Uses the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/api/) via [`requests`](https://pypi.org/project/requests/). Not based on the official [mailchimp-marketing-python](https://github.com/mailchimp/mailchimp-marketing-python) client. I hit too many issues with it so I went with raw HTTP calls instead.
 
@@ -47,6 +47,7 @@ Uses the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/api
 - **Webhooks** - Create and delete webhooks
 - **Templates** - Create, update, and delete email templates
 - **Automations** - Pause and start automation workflows
+- **E-commerce** - Cart lifecycle, promo rules, and promo codes for discount workflows
 - **Batch** - Run bulk API operations in a single request
 
 ## Prerequisites
@@ -346,6 +347,31 @@ Replace `mcp-cli` with your client's binary name. For read-only mode, add
 | `list_store_orders` | List orders from a store |
 | `list_store_products` | List products from a store |
 | `list_store_customers` | List customers from a store |
+
+### E-commerce Carts
+
+| Tool | Description |
+|---|---|
+| `list_store_carts` | List carts (including abandoned) for a store |
+| `get_store_cart` | Get a single cart with full line items |
+| `create_store_cart` | Push a cart (e.g. an abandoned cart from an external system) |
+| `update_store_cart` | Update a cart's totals, currency, checkout URL, or line items |
+| `delete_store_cart` | Permanently delete a cart |
+
+### E-commerce Promo Rules & Codes
+
+| Tool | Description |
+|---|---|
+| `list_promo_rules` | List discount rules for a store |
+| `get_promo_rule` | Get a single promo rule's configuration |
+| `create_promo_rule` | Create a discount rule (fixed amount, percentage, free shipping) |
+| `update_promo_rule` | Update a rule's amount, target, dates, or enabled state |
+| `delete_promo_rule` | Permanently delete a rule and all its codes |
+| `list_promo_codes` | List redeemable codes attached to a rule |
+| `get_promo_code` | Get a single promo code with usage stats |
+| `create_promo_code` | Create a redeemable code (e.g. 'SUMMER20') under a rule |
+| `update_promo_code` | Update a code's string, redemption URL, or enabled state |
+| `delete_promo_code` | Permanently delete a promo code |
 
 ### Batch Operations
 

--- a/glama.json
+++ b/glama.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "mailchimp-mcp",
-  "description": "MCP server for the Mailchimp Marketing API. 97 tools for managing campaigns, audiences, members, templates, segments, automations, reports, e-commerce, A/B testing, landing pages, CRM notes, and more.",
+  "description": "MCP server for the Mailchimp Marketing API. 112 tools for managing campaigns, audiences, members, templates, segments, automations, reports, e-commerce (carts, promo rules and codes), A/B testing, landing pages, CRM notes, and more.",
   "author": {
     "name": "Damien Tilman",
     "url": "https://github.com/damientilman"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mailchimp-mcp"
-version = "0.4.0"
+version = "0.5.0"
 description = "MCP server for the Mailchimp Marketing API — access campaigns, audiences, reports, and more from any MCP-compatible client."
 readme = "README.md"
 license = "MIT"

--- a/src/mailchimp_mcp_server/__init__.py
+++ b/src/mailchimp_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Mailchimp MCP Server — access Mailchimp data via the Model Context Protocol."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/src/mailchimp_mcp_server/server.py
+++ b/src/mailchimp_mcp_server/server.py
@@ -3129,6 +3129,658 @@ def list_store_customers(store_id: str, count: int = 20, offset: int = 0) -> str
     return json.dumps({"total_items": data.get("total_items"), "customers": customers}, indent=2)
 
 
+# --- Read/Write Tools: E-commerce Carts ---
+
+@mcp.tool()
+def list_store_carts(store_id: str, count: int = 20, offset: int = 0) -> str:
+    """List carts for a store, including abandoned ones, with customer and total info.
+
+    Carts in Mailchimp typically represent in-progress purchases synced from a connected
+    storefront. Use for abandoned-cart workflows: filter by recent created_at, segment by
+    cart total, then trigger a recovery automation. Use get_store_cart for a single cart
+    with line items. Use list_store_orders for completed purchases.
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+    Returns 404 if store_id is invalid.
+
+    Args:
+        store_id: E-commerce store ID. Obtain from list_ecommerce_stores.
+        count: Number of carts to return (1-1000, default 20).
+        offset: Pagination offset.
+
+    Returns:
+        JSON with store_id, total_items, and carts array. Each cart: id, customer (object
+        with id, email_address, opt_in_status), currency_code, order_total, tax_total,
+        checkout_url, created_at, updated_at.
+    """
+    data = mc_request(
+        f"/ecommerce/stores/{store_id}/carts",
+        params={"count": count, "offset": offset},
+    )
+    carts = []
+    for c in data.get("carts", []):
+        carts.append({
+            "id": c.get("id"),
+            "customer": c.get("customer"),
+            "currency_code": c.get("currency_code"),
+            "order_total": c.get("order_total"),
+            "tax_total": c.get("tax_total"),
+            "checkout_url": c.get("checkout_url"),
+            "created_at": c.get("created_at"),
+            "updated_at": c.get("updated_at"),
+        })
+    return json.dumps({
+        "store_id": store_id,
+        "total_items": data.get("total_items"),
+        "carts": carts,
+    }, indent=2)
+
+
+@mcp.tool()
+def get_store_cart(store_id: str, cart_id: str) -> str:
+    """Retrieve a single cart with its full line items, customer, and total breakdown.
+
+    Use to inspect what's in an abandoned cart before triggering a recovery email.
+    Use list_store_carts to browse and discover cart_ids.
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+    Returns 404 if store_id or cart_id is invalid.
+
+    Args:
+        store_id: E-commerce store ID. Obtain from list_ecommerce_stores.
+        cart_id: Cart ID. Obtain from list_store_carts.
+
+    Returns:
+        JSON with id, customer, currency_code, order_total, tax_total, checkout_url,
+        lines (array of {id, product_id, product_variant_id, quantity, price}),
+        created_at, updated_at.
+    """
+    data = mc_request(f"/ecommerce/stores/{store_id}/carts/{cart_id}")
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    return json.dumps({
+        "id": data.get("id"),
+        "customer": data.get("customer"),
+        "currency_code": data.get("currency_code"),
+        "order_total": data.get("order_total"),
+        "tax_total": data.get("tax_total"),
+        "checkout_url": data.get("checkout_url"),
+        "lines": data.get("lines"),
+        "created_at": data.get("created_at"),
+        "updated_at": data.get("updated_at"),
+    }, indent=2)
+
+
+@mcp.tool()
+def create_store_cart(store_id: str, cart_id: str, customer_id: str, currency_code: str, order_total: float, lines_json: str, checkout_url: Optional[str] = None, tax_total: Optional[float] = None) -> str:
+    """Create a cart in a store with line items and a customer reference. Used to push
+    abandoned-cart data from an external system into Mailchimp for recovery workflows.
+
+    cart_id is client-supplied (Mailchimp does not auto-generate it). The customer must
+    already exist in the store; create them via Mailchimp's customer endpoints first if
+    not. Use update_store_cart to modify after creation.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+
+    Args:
+        store_id: E-commerce store ID.
+        cart_id: Client-supplied unique ID for the new cart (e.g. 'cart_42').
+        customer_id: ID of an existing customer in the store.
+        currency_code: ISO 4217 currency code (e.g. 'USD', 'EUR').
+        order_total: Total order amount (line items + tax + shipping if any).
+        lines_json: JSON string with the cart line items array. Example:
+            '[{"id": "line_1", "product_id": "p_1", "product_variant_id": "p_1_red",
+               "quantity": 2, "price": 19.99}]'
+        checkout_url: Optional URL to resume the cart (used in recovery emails).
+        tax_total: Optional tax portion of order_total.
+
+    Returns:
+        JSON with id, customer, currency_code, order_total, checkout_url, created_at.
+    """
+    if (guard := _guard_write(action="create cart", store_id=store_id, cart_id=cart_id)):
+        return guard
+    try:
+        lines = json.loads(lines_json)
+    except json.JSONDecodeError as e:
+        return json.dumps({"error": f"Invalid lines_json: {e}"}, indent=2)
+    body: dict = {
+        "id": cart_id,
+        "customer": {"id": customer_id},
+        "currency_code": currency_code,
+        "order_total": order_total,
+        "lines": lines,
+    }
+    if checkout_url:
+        body["checkout_url"] = checkout_url
+    if tax_total is not None:
+        body["tax_total"] = tax_total
+    data = mc_request(f"/ecommerce/stores/{store_id}/carts", body=body, method="POST")
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    return json.dumps({
+        "id": data.get("id"),
+        "customer": data.get("customer"),
+        "currency_code": data.get("currency_code"),
+        "order_total": data.get("order_total"),
+        "checkout_url": data.get("checkout_url"),
+        "created_at": data.get("created_at"),
+    }, indent=2)
+
+
+@mcp.tool()
+def update_store_cart(store_id: str, cart_id: str, order_total: Optional[float] = None, tax_total: Optional[float] = None, checkout_url: Optional[str] = None, currency_code: Optional[str] = None, lines_json: Optional[str] = None) -> str:
+    """Update an existing cart's totals, currency, checkout URL, or line items.
+
+    Only provided fields are changed. To replace line items, pass a full lines_json array
+    (partial line updates are not supported by this tool — use the Mailchimp UI or REST
+    API directly for line-level edits).
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+    Returns 404 if store_id or cart_id is invalid.
+
+    Args:
+        store_id: E-commerce store ID.
+        cart_id: Existing cart ID.
+        order_total: New order total.
+        tax_total: New tax portion.
+        checkout_url: New checkout URL.
+        currency_code: New ISO 4217 currency code.
+        lines_json: JSON string with a replacement line items array.
+
+    Returns:
+        JSON with id, order_total, tax_total, checkout_url, currency_code, updated_at.
+    """
+    if (guard := _guard_write(action="update cart", store_id=store_id, cart_id=cart_id)):
+        return guard
+    body: dict = {}
+    if order_total is not None:
+        body["order_total"] = order_total
+    if tax_total is not None:
+        body["tax_total"] = tax_total
+    if checkout_url is not None:
+        body["checkout_url"] = checkout_url
+    if currency_code is not None:
+        body["currency_code"] = currency_code
+    if lines_json is not None:
+        try:
+            body["lines"] = json.loads(lines_json)
+        except json.JSONDecodeError as e:
+            return json.dumps({"error": f"Invalid lines_json: {e}"}, indent=2)
+    data = mc_request(f"/ecommerce/stores/{store_id}/carts/{cart_id}", body=body, method="PATCH")
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    return json.dumps({
+        "id": data.get("id"),
+        "order_total": data.get("order_total"),
+        "tax_total": data.get("tax_total"),
+        "checkout_url": data.get("checkout_url"),
+        "currency_code": data.get("currency_code"),
+        "updated_at": data.get("updated_at"),
+    }, indent=2)
+
+
+@mcp.tool()
+def delete_store_cart(store_id: str, cart_id: str) -> str:
+    """Permanently delete a cart from a store. Cannot be undone.
+
+    Use when an external system reports the cart has been completed (converted to order)
+    or expired. Does not affect related orders or customer records.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+    Returns 404 if store_id or cart_id is invalid.
+
+    Args:
+        store_id: E-commerce store ID.
+        cart_id: Cart ID to delete.
+
+    Returns:
+        JSON with status ('deleted'), store_id, cart_id on success.
+    """
+    if (guard := _guard_write(action="delete cart", store_id=store_id, cart_id=cart_id)):
+        return guard
+    result = mc_request(f"/ecommerce/stores/{store_id}/carts/{cart_id}", method="DELETE")
+    if isinstance(result, dict) and "error" in result:
+        return json.dumps(result, indent=2)
+    return json.dumps({"status": "deleted", "store_id": store_id, "cart_id": cart_id}, indent=2)
+
+
+# --- Read/Write Tools: E-commerce Promo Rules ---
+
+@mcp.tool()
+def list_promo_rules(store_id: str, count: int = 20, offset: int = 0) -> str:
+    """List discount/promo rules configured for a store (fixed amount, percentage, free shipping).
+
+    A promo rule defines the discount mechanic (e.g. '20% off entire order'). Codes that
+    customers redeem are attached to rules via list_promo_codes / create_promo_code.
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+
+    Args:
+        store_id: E-commerce store ID. Obtain from list_ecommerce_stores.
+        count: Number of rules to return (1-1000, default 20).
+        offset: Pagination offset.
+
+    Returns:
+        JSON with store_id, total_items, and promo_rules array. Each rule: id, title,
+        description, amount, type ('fixed' | 'percentage'), target ('per_item' | 'total' |
+        'shipping'), enabled (bool), starts_at, ends_at, created_at, updated_at.
+    """
+    data = mc_request(
+        f"/ecommerce/stores/{store_id}/promo-rules",
+        params={"count": count, "offset": offset},
+    )
+    rules = []
+    for r in data.get("promo_rules", []):
+        rules.append({
+            "id": r.get("id"),
+            "title": r.get("title"),
+            "description": r.get("description"),
+            "amount": r.get("amount"),
+            "type": r.get("type"),
+            "target": r.get("target"),
+            "enabled": r.get("enabled"),
+            "starts_at": r.get("starts_at"),
+            "ends_at": r.get("ends_at"),
+        })
+    return json.dumps({
+        "store_id": store_id,
+        "total_items": data.get("total_items"),
+        "promo_rules": rules,
+    }, indent=2)
+
+
+@mcp.tool()
+def get_promo_rule(store_id: str, promo_rule_id: str) -> str:
+    """Retrieve a single promo rule by ID with its full configuration.
+
+    Use to inspect a rule's current settings before updating, or to confirm a rule exists
+    before attaching new codes. Use list_promo_rules to browse and discover IDs.
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+    Returns 404 if store_id or promo_rule_id is invalid.
+
+    Args:
+        store_id: E-commerce store ID.
+        promo_rule_id: Rule ID to inspect.
+
+    Returns:
+        JSON with id, title, description, amount, type, target, enabled, starts_at,
+        ends_at, created_at, updated_at.
+    """
+    data = mc_request(f"/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}")
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    return json.dumps({
+        "id": data.get("id"),
+        "title": data.get("title"),
+        "description": data.get("description"),
+        "amount": data.get("amount"),
+        "type": data.get("type"),
+        "target": data.get("target"),
+        "enabled": data.get("enabled"),
+        "starts_at": data.get("starts_at"),
+        "ends_at": data.get("ends_at"),
+        "created_at": data.get("created_at"),
+        "updated_at": data.get("updated_at"),
+    }, indent=2)
+
+
+@mcp.tool()
+def create_promo_rule(store_id: str, promo_rule_id: str, description: str, amount: float, type: str, target: str, enabled: bool = True, title: Optional[str] = None, starts_at: Optional[str] = None, ends_at: Optional[str] = None) -> str:
+    """Create a promo rule (discount mechanic) in a store. Attach codes to it afterwards
+    via create_promo_code.
+
+    promo_rule_id is client-supplied. Common patterns: amount=20 + type='percentage' +
+    target='total' for '20% off entire order'; amount=5 + type='fixed' + target='shipping'
+    for '$5 off shipping'.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+
+    Args:
+        store_id: E-commerce store ID.
+        promo_rule_id: Client-supplied unique ID for the rule.
+        description: Internal description shown in Mailchimp UI.
+        amount: Discount value. For type='percentage', a value between 0 and 100.
+        type: 'fixed' for absolute amount or 'percentage' for percent off.
+        target: 'per_item' (each item), 'total' (whole order), or 'shipping' (shipping cost only).
+        enabled: Whether the rule is active. Default true.
+        title: Optional public title.
+        starts_at: Optional ISO 8601 start datetime (rule inactive before this).
+        ends_at: Optional ISO 8601 end datetime (rule inactive after this).
+
+    Returns:
+        JSON with id, title, description, amount, type, target, enabled, created_at.
+    """
+    if (guard := _guard_write(action="create promo rule", store_id=store_id, promo_rule_id=promo_rule_id)):
+        return guard
+    body: dict = {
+        "id": promo_rule_id,
+        "description": description,
+        "amount": amount,
+        "type": type,
+        "target": target,
+        "enabled": enabled,
+    }
+    if title:
+        body["title"] = title
+    if starts_at:
+        body["starts_at"] = starts_at
+    if ends_at:
+        body["ends_at"] = ends_at
+    data = mc_request(f"/ecommerce/stores/{store_id}/promo-rules", body=body, method="POST")
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    return json.dumps({
+        "id": data.get("id"),
+        "title": data.get("title"),
+        "description": data.get("description"),
+        "amount": data.get("amount"),
+        "type": data.get("type"),
+        "target": data.get("target"),
+        "enabled": data.get("enabled"),
+        "created_at": data.get("created_at"),
+    }, indent=2)
+
+
+@mcp.tool()
+def update_promo_rule(store_id: str, promo_rule_id: str, description: Optional[str] = None, amount: Optional[float] = None, type: Optional[str] = None, target: Optional[str] = None, enabled: Optional[bool] = None, title: Optional[str] = None, starts_at: Optional[str] = None, ends_at: Optional[str] = None) -> str:
+    """Update an existing promo rule. Only provided fields are changed.
+
+    Useful to toggle a rule on/off (enabled), extend an end date, or adjust the discount
+    amount mid-campaign. Use list_promo_rules to discover promo_rule_ids.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+    Returns 404 if store_id or promo_rule_id is invalid.
+
+    Args:
+        store_id: E-commerce store ID.
+        promo_rule_id: Existing rule ID.
+        description: New internal description.
+        amount: New discount amount.
+        type: New type ('fixed' or 'percentage').
+        target: New target ('per_item', 'total', or 'shipping').
+        enabled: Toggle the rule on/off.
+        title: New public title.
+        starts_at: New start datetime (ISO 8601).
+        ends_at: New end datetime (ISO 8601).
+
+    Returns:
+        JSON with id, title, description, amount, type, target, enabled, updated_at.
+    """
+    if (guard := _guard_write(action="update promo rule", store_id=store_id, promo_rule_id=promo_rule_id)):
+        return guard
+    body: dict = {}
+    for key, value in [
+        ("description", description),
+        ("amount", amount),
+        ("type", type),
+        ("target", target),
+        ("enabled", enabled),
+        ("title", title),
+        ("starts_at", starts_at),
+        ("ends_at", ends_at),
+    ]:
+        if value is not None:
+            body[key] = value
+    data = mc_request(
+        f"/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}",
+        body=body,
+        method="PATCH",
+    )
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    return json.dumps({
+        "id": data.get("id"),
+        "title": data.get("title"),
+        "description": data.get("description"),
+        "amount": data.get("amount"),
+        "type": data.get("type"),
+        "target": data.get("target"),
+        "enabled": data.get("enabled"),
+        "updated_at": data.get("updated_at"),
+    }, indent=2)
+
+
+@mcp.tool()
+def delete_promo_rule(store_id: str, promo_rule_id: str) -> str:
+    """Permanently delete a promo rule and all its associated promo codes. Irreversible.
+
+    Side effect: every promo code attached to this rule is also deleted and stops working
+    at checkout. Use update_promo_rule with enabled=false to disable a rule without
+    deleting its codes.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+    Returns 404 if store_id or promo_rule_id is invalid.
+
+    Args:
+        store_id: E-commerce store ID.
+        promo_rule_id: Rule ID to delete.
+
+    Returns:
+        JSON with status ('deleted'), store_id, promo_rule_id on success.
+    """
+    if (guard := _guard_write(action="delete promo rule", store_id=store_id, promo_rule_id=promo_rule_id)):
+        return guard
+    result = mc_request(
+        f"/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}",
+        method="DELETE",
+    )
+    if isinstance(result, dict) and "error" in result:
+        return json.dumps(result, indent=2)
+    return json.dumps({
+        "status": "deleted",
+        "store_id": store_id,
+        "promo_rule_id": promo_rule_id,
+    }, indent=2)
+
+
+# --- Read/Write Tools: E-commerce Promo Codes ---
+
+@mcp.tool()
+def list_promo_codes(store_id: str, promo_rule_id: str, count: int = 20, offset: int = 0) -> str:
+    """List the redeemable codes attached to a promo rule (e.g. 'SUMMER20', 'VIPONLY').
+
+    Codes are what customers type at checkout. They redeem the discount defined by the
+    rule. A single rule can have many codes (e.g. one per customer segment).
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+
+    Args:
+        store_id: E-commerce store ID.
+        promo_rule_id: Rule ID. Obtain from list_promo_rules.
+        count: Number of codes to return (1-1000, default 20).
+        offset: Pagination offset.
+
+    Returns:
+        JSON with store_id, promo_rule_id, total_items, and promo_codes array. Each code:
+        id, code (the string customers type), redemption_url, usage_count, enabled,
+        created_at, updated_at.
+    """
+    data = mc_request(
+        f"/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes",
+        params={"count": count, "offset": offset},
+    )
+    codes = []
+    for c in data.get("promo_codes", []):
+        codes.append({
+            "id": c.get("id"),
+            "code": c.get("code"),
+            "redemption_url": c.get("redemption_url"),
+            "usage_count": c.get("usage_count"),
+            "enabled": c.get("enabled"),
+            "created_at": c.get("created_at"),
+            "updated_at": c.get("updated_at"),
+        })
+    return json.dumps({
+        "store_id": store_id,
+        "promo_rule_id": promo_rule_id,
+        "total_items": data.get("total_items"),
+        "promo_codes": codes,
+    }, indent=2)
+
+
+@mcp.tool()
+def get_promo_code(store_id: str, promo_rule_id: str, promo_code_id: str) -> str:
+    """Retrieve a single promo code by ID with its current settings and usage stats.
+
+    Use to check a code's usage_count before a campaign, or confirm a code is enabled.
+    Use list_promo_codes to browse codes for a rule.
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+    Returns 404 if any of store_id, promo_rule_id, or promo_code_id is invalid.
+
+    Args:
+        store_id: E-commerce store ID.
+        promo_rule_id: Rule ID the code is attached to.
+        promo_code_id: Code ID to inspect.
+
+    Returns:
+        JSON with id, code, redemption_url, usage_count, enabled, created_at, updated_at.
+    """
+    data = mc_request(
+        f"/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes/{promo_code_id}"
+    )
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    return json.dumps({
+        "id": data.get("id"),
+        "code": data.get("code"),
+        "redemption_url": data.get("redemption_url"),
+        "usage_count": data.get("usage_count"),
+        "enabled": data.get("enabled"),
+        "created_at": data.get("created_at"),
+        "updated_at": data.get("updated_at"),
+    }, indent=2)
+
+
+@mcp.tool()
+def create_promo_code(store_id: str, promo_rule_id: str, promo_code_id: str, code: str, redemption_url: str, enabled: bool = True) -> str:
+    """Create a redeemable code under an existing promo rule.
+
+    Customers type the `code` string at checkout to apply the rule's discount. Code matching
+    is case-insensitive on the Mailchimp side. Use list_promo_codes to discover existing codes
+    before creating duplicates.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+    Returns 400 if promo_rule_id does not exist; returns 409 if promo_code_id already exists.
+
+    Args:
+        store_id: E-commerce store ID.
+        promo_rule_id: Rule ID to attach the code to. Obtain from list_promo_rules.
+        promo_code_id: Client-supplied unique ID for the code.
+        code: The actual code string customers type at checkout (e.g. 'SUMMER20').
+        redemption_url: URL where the code can be applied (your checkout page).
+        enabled: Whether the code is active. Default true.
+
+    Returns:
+        JSON with id, code, redemption_url, usage_count (0 at creation), enabled, created_at.
+    """
+    if (guard := _guard_write(action="create promo code", store_id=store_id, promo_rule_id=promo_rule_id, code=code)):
+        return guard
+    body = {
+        "id": promo_code_id,
+        "code": code,
+        "redemption_url": redemption_url,
+        "enabled": enabled,
+    }
+    data = mc_request(
+        f"/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes",
+        body=body,
+        method="POST",
+    )
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    return json.dumps({
+        "id": data.get("id"),
+        "code": data.get("code"),
+        "redemption_url": data.get("redemption_url"),
+        "usage_count": data.get("usage_count"),
+        "enabled": data.get("enabled"),
+        "created_at": data.get("created_at"),
+    }, indent=2)
+
+
+@mcp.tool()
+def update_promo_code(store_id: str, promo_rule_id: str, promo_code_id: str, code: Optional[str] = None, redemption_url: Optional[str] = None, enabled: Optional[bool] = None) -> str:
+    """Update a promo code's string, redemption URL, or enabled state. Cannot move a code
+    to a different rule — delete and re-create instead.
+
+    Common use: toggle enabled=false to temporarily disable a code after a campaign ends,
+    without deleting the redemption history.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+    Returns 404 if any of store_id, promo_rule_id, or promo_code_id is invalid.
+
+    Args:
+        store_id: E-commerce store ID.
+        promo_rule_id: Rule ID the code is attached to.
+        promo_code_id: Code ID to update.
+        code: New code string (case-insensitive).
+        redemption_url: New redemption URL.
+        enabled: Toggle the code on/off.
+
+    Returns:
+        JSON with id, code, redemption_url, enabled, updated_at.
+    """
+    if (guard := _guard_write(action="update promo code", store_id=store_id, promo_rule_id=promo_rule_id, promo_code_id=promo_code_id)):
+        return guard
+    body: dict = {}
+    if code is not None:
+        body["code"] = code
+    if redemption_url is not None:
+        body["redemption_url"] = redemption_url
+    if enabled is not None:
+        body["enabled"] = enabled
+    data = mc_request(
+        f"/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes/{promo_code_id}",
+        body=body,
+        method="PATCH",
+    )
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    return json.dumps({
+        "id": data.get("id"),
+        "code": data.get("code"),
+        "redemption_url": data.get("redemption_url"),
+        "enabled": data.get("enabled"),
+        "updated_at": data.get("updated_at"),
+    }, indent=2)
+
+
+@mcp.tool()
+def delete_promo_code(store_id: str, promo_rule_id: str, promo_code_id: str) -> str:
+    """Permanently delete a promo code. Past redemption history is lost. Irreversible.
+
+    Use update_promo_code with enabled=false to disable a code while preserving its
+    redemption stats. Use delete_promo_rule to remove the rule and all its codes at once.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+    Returns 404 if any of store_id, promo_rule_id, or promo_code_id is invalid.
+
+    Args:
+        store_id: E-commerce store ID.
+        promo_rule_id: Rule ID the code is attached to.
+        promo_code_id: Code ID to delete.
+
+    Returns:
+        JSON with status ('deleted'), store_id, promo_rule_id, promo_code_id on success.
+    """
+    if (guard := _guard_write(action="delete promo code", store_id=store_id, promo_rule_id=promo_rule_id, promo_code_id=promo_code_id)):
+        return guard
+    result = mc_request(
+        f"/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes/{promo_code_id}",
+        method="DELETE",
+    )
+    if isinstance(result, dict) and "error" in result:
+        return json.dumps(result, indent=2)
+    return json.dumps({
+        "status": "deleted",
+        "store_id": store_id,
+        "promo_rule_id": promo_rule_id,
+        "promo_code_id": promo_code_id,
+    }, indent=2)
+
+
 # --- Read Tools: Campaign Folders ---
 
 @mcp.tool()

--- a/tests/test_tools_smoke.py
+++ b/tests/test_tools_smoke.py
@@ -423,3 +423,225 @@ class TestMemberNotesCRUD:
         assert payload == {"status": "deleted", "email_address": self.EMAIL, "note_id": "7"}
         assert calls[0]["method"] == "DELETE"
         assert calls[0]["endpoint"] == f"/lists/abc/members/{self.HASH}/notes/7"
+
+
+class TestEcommerceCartsCRUD:
+    def test_list_store_carts(self, mock_mc_request) -> None:
+        mock_mc_request(
+            {
+                "total_items": 1,
+                "carts": [
+                    {
+                        "id": "cart_1",
+                        "customer": {"id": "cust_1", "email_address": "a@b.com"},
+                        "currency_code": "EUR",
+                        "order_total": 49.99,
+                        "checkout_url": "https://shop.example/cart/cart_1",
+                        "created_at": "2026-05-16T00:00:00Z",
+                    }
+                ],
+            }
+        )
+        payload = json.loads(server.list_store_carts(store_id="store_a"))
+        assert payload["total_items"] == 1
+        assert payload["carts"][0]["currency_code"] == "EUR"
+
+    def test_get_store_cart(self, mock_mc_request) -> None:
+        calls = mock_mc_request(
+            {
+                "id": "cart_1",
+                "customer": {"id": "cust_1"},
+                "currency_code": "EUR",
+                "order_total": 49.99,
+                "lines": [{"id": "line_1", "product_id": "p_1", "quantity": 2, "price": 24.99}],
+            }
+        )
+        payload = json.loads(server.get_store_cart(store_id="store_a", cart_id="cart_1"))
+        assert payload["lines"][0]["quantity"] == 2
+        assert calls[0]["endpoint"] == "/ecommerce/stores/store_a/carts/cart_1"
+
+    def test_create_store_cart_parses_lines_json(self, mock_mc_request) -> None:
+        calls = mock_mc_request(
+            {"id": "cart_42", "customer": {"id": "cust_1"}, "currency_code": "EUR", "order_total": 19.99}
+        )
+        lines = json.dumps([{"id": "line_1", "product_id": "p_1", "quantity": 1, "price": 19.99}])
+        server.create_store_cart(
+            store_id="store_a",
+            cart_id="cart_42",
+            customer_id="cust_1",
+            currency_code="EUR",
+            order_total=19.99,
+            lines_json=lines,
+        )
+        body = calls[0]["body"]
+        assert body["id"] == "cart_42"
+        assert body["customer"] == {"id": "cust_1"}
+        assert body["lines"][0]["product_id"] == "p_1"
+        assert calls[0]["method"] == "POST"
+
+    def test_create_store_cart_rejects_invalid_lines_json(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"should": "not-be-called"})
+        result = server.create_store_cart(
+            store_id="store_a",
+            cart_id="cart_42",
+            customer_id="cust_1",
+            currency_code="EUR",
+            order_total=19.99,
+            lines_json="{not json",
+        )
+        payload = json.loads(result)
+        assert "Invalid lines_json" in payload["error"]
+        assert calls == []
+
+    def test_update_store_cart_only_sends_provided_fields(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"id": "cart_1", "order_total": 99.99})
+        server.update_store_cart(store_id="store_a", cart_id="cart_1", order_total=99.99)
+        body = calls[0]["body"]
+        assert body == {"order_total": 99.99}
+        assert calls[0]["method"] == "PATCH"
+
+    def test_delete_store_cart(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"status": "success"})
+        payload = json.loads(server.delete_store_cart(store_id="store_a", cart_id="cart_1"))
+        assert payload == {"status": "deleted", "store_id": "store_a", "cart_id": "cart_1"}
+        assert calls[0]["method"] == "DELETE"
+
+
+class TestEcommercePromoRulesCRUD:
+    def test_list_promo_rules(self, mock_mc_request) -> None:
+        mock_mc_request(
+            {
+                "total_items": 1,
+                "promo_rules": [
+                    {
+                        "id": "rule_1",
+                        "title": "Summer Sale",
+                        "description": "20% off",
+                        "amount": 20,
+                        "type": "percentage",
+                        "target": "total",
+                        "enabled": True,
+                    }
+                ],
+            }
+        )
+        payload = json.loads(server.list_promo_rules(store_id="store_a"))
+        assert payload["promo_rules"][0]["type"] == "percentage"
+
+    def test_get_promo_rule(self, mock_mc_request) -> None:
+        mock_mc_request({"id": "rule_1", "type": "percentage", "amount": 20, "enabled": True})
+        payload = json.loads(server.get_promo_rule(store_id="store_a", promo_rule_id="rule_1"))
+        assert payload["amount"] == 20
+
+    def test_create_promo_rule(self, mock_mc_request) -> None:
+        calls = mock_mc_request(
+            {
+                "id": "rule_42",
+                "description": "Summer 20%",
+                "amount": 20,
+                "type": "percentage",
+                "target": "total",
+                "enabled": True,
+                "created_at": "2026-05-16T00:00:00Z",
+            }
+        )
+        server.create_promo_rule(
+            store_id="store_a",
+            promo_rule_id="rule_42",
+            description="Summer 20%",
+            amount=20,
+            type="percentage",
+            target="total",
+            starts_at="2026-06-01T00:00:00Z",
+        )
+        body = calls[0]["body"]
+        assert body["id"] == "rule_42"
+        assert body["type"] == "percentage"
+        assert body["target"] == "total"
+        assert body["starts_at"] == "2026-06-01T00:00:00Z"
+        assert "ends_at" not in body
+        assert calls[0]["method"] == "POST"
+
+    def test_update_promo_rule_enabled_toggle(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"id": "rule_1", "enabled": False, "updated_at": "2026-05-17T00:00:00Z"})
+        server.update_promo_rule(store_id="store_a", promo_rule_id="rule_1", enabled=False)
+        body = calls[0]["body"]
+        assert body == {"enabled": False}
+        assert calls[0]["method"] == "PATCH"
+
+    def test_delete_promo_rule(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"status": "success"})
+        payload = json.loads(server.delete_promo_rule(store_id="store_a", promo_rule_id="rule_1"))
+        assert payload["status"] == "deleted"
+        assert calls[0]["method"] == "DELETE"
+
+
+class TestEcommercePromoCodesCRUD:
+    def test_list_promo_codes(self, mock_mc_request) -> None:
+        mock_mc_request(
+            {
+                "total_items": 1,
+                "promo_codes": [
+                    {
+                        "id": "code_1",
+                        "code": "SUMMER20",
+                        "redemption_url": "https://shop.example/checkout",
+                        "usage_count": 12,
+                        "enabled": True,
+                    }
+                ],
+            }
+        )
+        payload = json.loads(
+            server.list_promo_codes(store_id="store_a", promo_rule_id="rule_1")
+        )
+        assert payload["promo_codes"][0]["code"] == "SUMMER20"
+        assert payload["promo_codes"][0]["usage_count"] == 12
+
+    def test_get_promo_code(self, mock_mc_request) -> None:
+        mock_mc_request({"id": "code_1", "code": "SUMMER20", "usage_count": 12, "enabled": True})
+        payload = json.loads(
+            server.get_promo_code(store_id="store_a", promo_rule_id="rule_1", promo_code_id="code_1")
+        )
+        assert payload["code"] == "SUMMER20"
+
+    def test_create_promo_code(self, mock_mc_request) -> None:
+        calls = mock_mc_request(
+            {
+                "id": "code_42",
+                "code": "VIP25",
+                "redemption_url": "https://shop.example/checkout",
+                "usage_count": 0,
+                "enabled": True,
+                "created_at": "2026-05-16T00:00:00Z",
+            }
+        )
+        server.create_promo_code(
+            store_id="store_a",
+            promo_rule_id="rule_1",
+            promo_code_id="code_42",
+            code="VIP25",
+            redemption_url="https://shop.example/checkout",
+        )
+        body = calls[0]["body"]
+        assert body["id"] == "code_42"
+        assert body["code"] == "VIP25"
+        assert body["enabled"] is True
+        assert calls[0]["endpoint"] == "/ecommerce/stores/store_a/promo-rules/rule_1/promo-codes"
+
+    def test_update_promo_code_disable(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"id": "code_1", "enabled": False})
+        server.update_promo_code(
+            store_id="store_a", promo_rule_id="rule_1", promo_code_id="code_1", enabled=False
+        )
+        assert calls[0]["body"] == {"enabled": False}
+        assert calls[0]["method"] == "PATCH"
+
+    def test_delete_promo_code(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"status": "success"})
+        payload = json.loads(
+            server.delete_promo_code(store_id="store_a", promo_rule_id="rule_1", promo_code_id="code_1")
+        )
+        assert payload["status"] == "deleted"
+        assert payload["promo_code_id"] == "code_1"
+        assert calls[0]["method"] == "DELETE"


### PR DESCRIPTION
## Summary

Implements the high-value subset of #19: e-commerce write operations focused on the parts that are actually useful given how Mailchimp's commerce API works in practice.

- **Cart CRUD** (5 tools) — `list_store_carts`, `get_store_cart`, `create_store_cart`, `update_store_cart`, `delete_store_cart`. Designed for abandoned-cart workflows where the cart originates in an external system (Shopify, custom storefront, etc.). Line items are passed as JSON in create/update.
- **Promo rule CRUD** (5 tools) — `list_promo_rules`, `get_promo_rule`, `create_promo_rule`, `update_promo_rule`, `delete_promo_rule`. Defines the discount mechanic: fixed amount or percentage, targeting per-item / total / shipping. `enabled` toggle lets you pause a rule without deleting its attached codes.
- **Promo code CRUD** (5 tools) — `list_promo_codes`, `get_promo_code`, `create_promo_code`, `update_promo_code`, `delete_promo_code`. Manages the redeemable codes attached to a rule, with `usage_count` exposed for campaign-driven tracking.

Tool count: **97 → 112**.

### Scope decision on #19

The original issue asks for "full CRUD for stores, orders, products, variants, carts, promo rules/codes, customers". The high-value subset (carts + promo rules + promo codes) is implemented here. Stores, customers, orders, products, and variants writes are **intentionally deferred** because in 99% of Mailchimp setups, that data is synced one-way from external storefronts (Shopify, Woo) and write-back is rarely useful. Closing #19 as partially-implemented; happy to reopen a follow-up issue if anyone has a specific use case for the deferred writes.

Closes #19.

## Test plan

- [x] `uv run pytest` — 63/63 tests pass in ~0.1s
- [x] `uv run ruff check src/ tests/` — clean
- [x] Smoke tests for each of the 15 new tools, plus error paths (invalid lines JSON, partial PATCH bodies)
- [ ] Manual sanity check against a real Mailchimp sandbox store (optional)

## Notes for the release

- After merge, tag `v0.5.0` — the publish workflow will trigger automatically and push the package to PyPI via Trusted Publishers (OIDC).
- CHANGELOG entry added under `[0.5.0]`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbgaDAfLrHxDmXVAW2f8MT)_