### PR TITLE
Release v0.6.0: Customer Journey workarounds and automation summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05
+
+### Added
+- **`search_automation_campaigns`** — list campaigns where `type='automation'`, with
+  optional filters by audience, status, and date range. The most practical
+  workaround for the lack of a public Customer Journeys read API: while the journey
+  graph itself stays private, every email a journey emits creates a campaign
+  surface-able through this tool.
+- **`get_member_journey_events`** — retrieve a member's activity feed filtered
+  client-side to actions whose type contains `"automation"` or `"journey"`. Useful
+  to answer "what automation/journey emails has this contact received?".
+- **`get_automation_summary`** — combined overview tool: counts Classic Automation
+  workflows by status, plus aggregate send volume from automation-type campaigns
+  in a configurable lookback window (default 30 days). Recommended starting point
+  for account audits.
+- 4 new tests covering filter wiring, server-side action filtering, and the
+  multi-call aggregation in the summary tool.
+
+### Changed
+- Tool count bumped to **115** (was 112) — README, `glama.json`, and
+  `pyproject.toml` descriptions updated accordingly.
+- `list_automations` docstring now states clearly that Customer Journeys are NOT
+  returned (Mailchimp does not expose a public read endpoint for them), and points
+  at the new workaround tools.
+- README's Automations section renamed to "Automations & Customer Journeys" and
+  expanded to document the journey coverage gap and the recommended workarounds.
+
 ## [0.5.0] - 2026-05
 
 ### Added
@@ -134,7 +161,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   landing pages, e-commerce, and batch operations.
 - MIT license, Python 3.10+ support, MCP-compatible via FastMCP.
 
-[Unreleased]: https://github.com/damientilman/mailchimp-mcp-server/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/damientilman/mailchimp-mcp-server/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/damientilman/mailchimp-mcp-server/releases/tag/v0.6.0
 [0.5.0]: https://github.com/damientilman/mailchimp-mcp-server/releases/tag/v0.5.0
 [0.4.0]: https://github.com/damientilman/mailchimp-mcp-server/releases/tag/v0.4.0
 [0.3.0]: https://github.com/damientilman/mailchimp-mcp-server/releases/tag/v0.3.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![MCP](https://img.shields.io/badge/MCP-compatible-green.svg)](https://modelcontextprotocol.io)
 
-The most complete [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/) — **112 tools** to query and manage your Mailchimp account from any MCP-compatible client, with A/B campaign support, geographic reporting, full landing-page lifecycle, CRM-style member notes, e-commerce carts and promo codes, and read-only / dry-run safety modes.
+The most complete [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/) — **115 tools** to query and manage your Mailchimp account from any MCP-compatible client, with A/B campaign support, geographic reporting, full landing-page lifecycle, CRM-style member notes, e-commerce carts and promo codes, Classic Automation + Customer Journey reporting, and read-only / dry-run safety modes.
 
 Uses the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/api/) via [`requests`](https://pypi.org/project/requests/). Not based on the official [mailchimp-marketing-python](https://github.com/mailchimp/mailchimp-marketing-python) client. I hit too many issues with it so I went with raw HTTP calls instead.
 
@@ -306,15 +306,21 @@ Replace `mcp-cli` with your client's binary name. For read-only mode, add
 | `create_webhook` | Create a new webhook |
 | `delete_webhook` | Delete a webhook |
 
-### Automations
+### Automations & Customer Journeys
 
 | Tool | Description |
 |---|---|
-| `list_automations` | List automated email workflows |
-| `get_automation_emails` | List emails in a workflow |
+| `list_automations` | List Classic Automation workflows (Customer Journeys are not exposed by Mailchimp's API) |
+| `get_automation_emails` | List emails in a Classic workflow |
 | `get_automation_email_queue` | View the send queue for an automation email |
-| `pause_automation` | Pause all emails in a workflow |
-| `start_automation` | Start/resume all emails in a workflow |
+| `pause_automation` | Pause all emails in a Classic workflow |
+| `start_automation` | Start/resume all emails in a Classic workflow |
+| `trigger_customer_journey` | Enroll a contact into a Customer Journey step (the only journey write Mailchimp exposes) |
+| `search_automation_campaigns` | List campaigns emitted by either Classic Automations or Customer Journeys |
+| `get_member_journey_events` | Filter a member's activity feed to automation/journey-related events |
+| `get_automation_summary` | Combined overview: Classic workflows by status + recent automation send volume |
+
+> Mailchimp does not expose a public read API for Customer Journeys (only the trigger endpoint above). The `search_automation_campaigns`, `get_member_journey_events` and `get_automation_summary` tools provide the recommended workarounds — they surface every campaign emitted by automations or journeys, even though the journey graph itself remains private.
 
 ### Templates
 

--- a/glama.json
+++ b/glama.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "mailchimp-mcp",
-  "description": "MCP server for the Mailchimp Marketing API. 112 tools for managing campaigns, audiences, members, templates, segments, automations, reports, e-commerce (carts, promo rules and codes), A/B testing, landing pages, CRM notes, and more.",
+  "description": "MCP server for the Mailchimp Marketing API. 115 tools for managing campaigns, audiences, members, templates, segments, Classic Automations and Customer Journey workarounds, reports, e-commerce (carts, promo rules and codes), A/B testing, landing pages, CRM notes, and more.",
   "author": {
     "name": "Damien Tilman",
     "url": "https://github.com/damientilman"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mailchimp-mcp"
-version = "0.5.0"
+version = "0.6.0"
 description = "MCP server for the Mailchimp Marketing API — access campaigns, audiences, reports, and more from any MCP-compatible client."
 readme = "README.md"
 license = "MIT"

--- a/src/mailchimp_mcp_server/__init__.py
+++ b/src/mailchimp_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Mailchimp MCP Server — access Mailchimp data via the Model Context Protocol."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/src/mailchimp_mcp_server/server.py
+++ b/src/mailchimp_mcp_server/server.py
@@ -424,11 +424,14 @@ def get_audience_growth_history(list_id: str, count: int = 12) -> str:
 
 @mcp.tool()
 def list_automations(count: int = 20, offset: int = 0) -> str:
-    """List automation workflows in the account with status and send counts.
+    """List Classic Automation workflows in the account with status and send counts.
 
-    Returns all automations regardless of status (sending, paused, draft), ordered by creation
-    date descending. Includes both Classic Automations and Customer Journeys. Use
-    get_automation_emails for individual emails within a workflow.
+    Returns Classic Automations only — ordered by creation date descending. Customer Journeys
+    are NOT returned (Mailchimp does not expose a public read endpoint for journeys; only the
+    journey-step trigger endpoint is public). To see what your Customer Journeys are sending,
+    use search_automation_campaigns instead (it lists every campaign emitted by either system).
+    Use get_automation_emails for individual emails within a Classic workflow. Use
+    get_automation_summary for a counted overview combining both systems.
 
     Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
 
@@ -453,6 +456,77 @@ def list_automations(count: int = 20, offset: int = 0) -> str:
             "list_id": a.get("recipients", {}).get("list_id"),
         })
     return json.dumps({"total_items": data.get("total_items"), "automations": automations}, indent=2)
+
+
+@mcp.tool()
+def get_automation_summary(days: int = 30) -> str:
+    """Summarise automation activity across Classic Automations and Customer Journeys.
+
+    Combines two API calls into a single overview useful for audits and dashboards:
+    1. /automations to count Classic workflows by status (sending / paused / draft)
+    2. /campaigns?type=automation&since_send_time=N days ago to count and sum what
+       automations have actually sent recently (both Classic and Customer Journey emails
+       show up as type='automation' campaigns)
+
+    This is the recommended starting point for "what's my automation stack doing right now?"
+    questions during an account audit. Use list_automations for the raw Classic list. Use
+    search_automation_campaigns for the raw recent automation campaign feed.
+
+    Authenticated via API key. Max 10 concurrent requests (2 are issued by this tool).
+    Read-only, safe to retry.
+
+    Args:
+        days: Lookback window in days for the recent-sends portion (1-365, default 30).
+
+    Returns:
+        JSON with two sections:
+        - classic_automations: total, by_status ({sending, paused, draft, ...})
+        - recent_automation_campaigns: window_days, total_campaigns, total_emails_sent,
+          top_titles (up to 5 titles ordered by emails_sent desc)
+    """
+    automations_data = mc_request("/automations", params={"count": 1000})
+    by_status: dict = {}
+    classic_total = 0
+    if isinstance(automations_data, dict) and "error" not in automations_data:
+        for a in automations_data.get("automations", []):
+            classic_total += 1
+            status = a.get("status") or "unknown"
+            by_status[status] = by_status.get(status, 0) + 1
+
+    from datetime import datetime, timedelta, timezone
+    since = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    campaigns_data = mc_request(
+        "/campaigns",
+        params={"count": 1000, "type": "automation", "since_send_time": since},
+    )
+    recent_campaigns: list = []
+    recent_emails_sent = 0
+    if isinstance(campaigns_data, dict) and "error" not in campaigns_data:
+        for c in campaigns_data.get("campaigns", []):
+            sent = c.get("emails_sent") or 0
+            recent_emails_sent += sent
+            recent_campaigns.append({
+                "title": c.get("settings", {}).get("title"),
+                "emails_sent": sent,
+            })
+    recent_campaigns.sort(key=lambda c: c.get("emails_sent") or 0, reverse=True)
+    top_titles = [
+        {"title": c["title"], "emails_sent": c["emails_sent"]}
+        for c in recent_campaigns[:5]
+    ]
+
+    return json.dumps({
+        "classic_automations": {
+            "total": classic_total,
+            "by_status": by_status,
+        },
+        "recent_automation_campaigns": {
+            "window_days": days,
+            "total_campaigns": len(recent_campaigns),
+            "total_emails_sent": recent_emails_sent,
+            "top_titles": top_titles,
+        },
+    }, indent=2)
 
 
 @mcp.tool()
@@ -2481,6 +2555,58 @@ def get_member_events(list_id: str, email_address: str, count: int = 20) -> str:
     return json.dumps({"email_address": email_address, "total_items": data.get("total_items"), "events": events}, indent=2)
 
 
+@mcp.tool()
+def get_member_journey_events(list_id: str, email_address: str, count: int = 50) -> str:
+    """Retrieve a member's activity events filtered to automation- and journey-related actions.
+
+    Returns the subset of the member's activity feed that relates to Classic Automations and
+    (where Mailchimp surfaces them) Customer Journey emails. Useful to answer "what automation
+    or journey emails has this contact received?" without scanning their full activity.
+
+    Note: Mailchimp does not expose a public read API for Customer Journeys themselves. Journey
+    emails do appear in the activity feed as automation-typed actions, so this tool surfaces them
+    via that side-channel rather than reading the journey graph directly. Use trigger_customer_journey
+    to enroll a contact into a specific journey step (the only journey write available via API).
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+
+    Args:
+        list_id: Audience/list ID (10-char alphanumeric). Obtain from list_audiences.
+        email_address: Email of the member. Must exist in the audience.
+        count: Number of activity rows to scan before filtering (1-1000, default 50). Raise if
+            the member is highly active and you suspect automation events are missed.
+
+    Returns:
+        JSON with email_address, scanned (raw row count looked at), total_journey_events (after
+        filtering), and events array. Each event: action (raw action type), timestamp, title
+        (campaign / automation title if present), url (link clicked if any), campaign_id.
+    """
+    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    data = mc_request(
+        f"/lists/{list_id}/members/{subscriber_hash}/activity-feed",
+        params={"count": count},
+    )
+    automation_keywords = ("automation", "journey")
+    filtered = []
+    raw_activity = data.get("activity", [])
+    for a in raw_activity:
+        action = (a.get("action") or "").lower()
+        if any(k in action for k in automation_keywords):
+            filtered.append({
+                "action": a.get("action"),
+                "timestamp": a.get("timestamp"),
+                "title": a.get("title"),
+                "url": a.get("url"),
+                "campaign_id": a.get("campaign_id"),
+            })
+    return json.dumps({
+        "email_address": email_address,
+        "scanned": len(raw_activity),
+        "total_journey_events": len(filtered),
+        "events": filtered,
+    }, indent=2)
+
+
 # --- Read/Write Tools: Member Notes ---
 
 @mcp.tool()
@@ -3964,6 +4090,61 @@ def search_campaigns(query: str, count: int = 20, offset: int = 0) -> str:
             }
         })
     return json.dumps({"total_items": data.get("total_items"), "results": results}, indent=2)
+
+
+@mcp.tool()
+def search_automation_campaigns(count: int = 20, offset: int = 0, list_id: Optional[str] = None, status: Optional[str] = None, since_send_time: Optional[str] = None, before_send_time: Optional[str] = None) -> str:
+    """List campaigns originated by an automation or a Customer Journey (campaign type='automation').
+
+    Every email Mailchimp sends from a Classic automation or a Customer Journey creates a
+    campaign object with type='automation'. This tool filters /campaigns to surface only those,
+    so you can answer "what did my automations send recently?" without scanning all campaigns.
+
+    Use this as the most practical workaround for the lack of a public Customer Journeys read
+    API: while you can't list the journeys themselves, you can list the campaigns they emit.
+    Use list_automations for Classic-only metadata (journey internals aren't exposed). Use
+    list_campaigns for the full campaign feed.
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+
+    Args:
+        count: Number of campaigns to return (1-1000, default 20).
+        offset: Pagination offset. Use when total_items exceeds count.
+        list_id: Optional audience ID to restrict to a single audience. Obtain from list_audiences.
+        status: Filter by campaign status. Valid values: 'save', 'paused', 'schedule', 'sending',
+            'sent'. Omit for all.
+        since_send_time: Only return campaigns sent after this ISO 8601 datetime (e.g.
+            '2026-04-01T00:00:00Z').
+        before_send_time: Only return campaigns sent before this ISO 8601 datetime.
+
+    Returns:
+        JSON with total_items and campaigns array. Each campaign: id, status, title, subject_line,
+        send_time, emails_sent, list_id, list_name. Useful to compute automation send volume and
+        identify which automation/journey produced which email (via title patterns).
+    """
+    params: dict = {"count": count, "offset": offset, "type": "automation"}
+    if list_id:
+        params["list_id"] = list_id
+    if status:
+        params["status"] = status
+    if since_send_time:
+        params["since_send_time"] = since_send_time
+    if before_send_time:
+        params["before_send_time"] = before_send_time
+    data = mc_request("/campaigns", params=params)
+    campaigns = []
+    for c in data.get("campaigns", []):
+        campaigns.append({
+            "id": c.get("id"),
+            "status": c.get("status"),
+            "title": c.get("settings", {}).get("title"),
+            "subject_line": c.get("settings", {}).get("subject_line"),
+            "send_time": c.get("send_time"),
+            "emails_sent": c.get("emails_sent"),
+            "list_id": c.get("recipients", {}).get("list_id"),
+            "list_name": c.get("recipients", {}).get("list_name"),
+        })
+    return json.dumps({"total_items": data.get("total_items"), "campaigns": campaigns}, indent=2)
 
 
 @mcp.tool()

--- a/tests/test_tools_smoke.py
+++ b/tests/test_tools_smoke.py
@@ -645,3 +645,106 @@ class TestEcommercePromoCodesCRUD:
         assert payload["status"] == "deleted"
         assert payload["promo_code_id"] == "code_1"
         assert calls[0]["method"] == "DELETE"
+
+
+class TestAutomationCoverage:
+    EMAIL = "jane@example.com"
+    HASH = "9e26471d35a78862c17e467d87cddedf"
+
+    def test_search_automation_campaigns_forces_type_filter(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"total_items": 0, "campaigns": []})
+        server.search_automation_campaigns(count=50)
+        params = calls[0]["params"]
+        assert params["type"] == "automation"
+        assert params["count"] == 50
+        assert "list_id" not in params
+        assert "since_send_time" not in params
+
+    def test_search_automation_campaigns_threads_optional_filters(self, mock_mc_request) -> None:
+        calls = mock_mc_request(
+            {
+                "total_items": 1,
+                "campaigns": [
+                    {
+                        "id": "cam_1",
+                        "status": "sent",
+                        "settings": {"title": "Welcome day 1", "subject_line": "Welcome"},
+                        "send_time": "2026-05-01T10:00:00Z",
+                        "emails_sent": 1200,
+                        "recipients": {"list_id": "list_a", "list_name": "Main"},
+                    }
+                ],
+            }
+        )
+        server.search_automation_campaigns(
+            list_id="list_a",
+            status="sent",
+            since_send_time="2026-04-01T00:00:00Z",
+            before_send_time="2026-06-01T00:00:00Z",
+        )
+        params = calls[0]["params"]
+        assert params["type"] == "automation"
+        assert params["list_id"] == "list_a"
+        assert params["status"] == "sent"
+        assert params["since_send_time"] == "2026-04-01T00:00:00Z"
+        assert params["before_send_time"] == "2026-06-01T00:00:00Z"
+
+    def test_get_member_journey_events_filters_activity_feed(self, mock_mc_request) -> None:
+        calls = mock_mc_request(
+            {
+                "activity": [
+                    {"action": "automation_email_sent", "timestamp": "2026-05-01T10:00:00Z", "title": "Welcome", "campaign_id": "cam_1"},
+                    {"action": "open", "timestamp": "2026-05-01T11:00:00Z", "title": "Welcome", "campaign_id": "cam_1"},
+                    {"action": "journey_step_entered", "timestamp": "2026-05-02T09:00:00Z", "title": "Onboarding"},
+                    {"action": "click", "url": "https://example.com", "timestamp": "2026-05-02T10:00:00Z"},
+                ]
+            }
+        )
+        payload = json.loads(server.get_member_journey_events(list_id="abc", email_address=self.EMAIL))
+        assert payload["scanned"] == 4
+        assert payload["total_journey_events"] == 2
+        actions = [e["action"] for e in payload["events"]]
+        assert "automation_email_sent" in actions
+        assert "journey_step_entered" in actions
+        assert "open" not in actions
+        assert "click" not in actions
+        assert calls[0]["endpoint"] == f"/lists/abc/members/{self.HASH}/activity-feed"
+
+    def test_get_automation_summary_combines_two_calls(self, mock_mc_request) -> None:
+        calls = mock_mc_request([
+            {
+                "total_items": 4,
+                "automations": [
+                    {"id": "a1", "status": "sending"},
+                    {"id": "a2", "status": "sending"},
+                    {"id": "a3", "status": "paused"},
+                    {"id": "a4", "status": "save"},
+                ],
+            },
+            {
+                "total_items": 2,
+                "campaigns": [
+                    {"settings": {"title": "Welcome day 1"}, "emails_sent": 4200},
+                    {"settings": {"title": "Welcome day 3"}, "emails_sent": 1800},
+                ],
+            },
+        ])
+        payload = json.loads(server.get_automation_summary(days=14))
+
+        assert payload["classic_automations"]["total"] == 4
+        assert payload["classic_automations"]["by_status"]["sending"] == 2
+        assert payload["classic_automations"]["by_status"]["paused"] == 1
+        assert payload["classic_automations"]["by_status"]["save"] == 1
+
+        recent = payload["recent_automation_campaigns"]
+        assert recent["window_days"] == 14
+        assert recent["total_campaigns"] == 2
+        assert recent["total_emails_sent"] == 6000
+        assert recent["top_titles"][0]["title"] == "Welcome day 1"
+        assert recent["top_titles"][0]["emails_sent"] == 4200
+
+        assert len(calls) == 2
+        assert calls[0]["endpoint"] == "/automations"
+        assert calls[1]["endpoint"] == "/campaigns"
+        assert calls[1]["params"]["type"] == "automation"
+        assert "since_send_time" in calls[1]["params"]


### PR DESCRIPTION
## Summary

Adds three tools that address one of the most-asked questions in the Mailchimp dev community: **how to read/manage Customer Journeys via API**. The honest answer is "you can't directly — Mailchimp only exposes the journey-step trigger endpoint publicly". This release adds the practical workarounds:

- **`search_automation_campaigns`** — filter `/campaigns` to `type='automation'`, optionally by audience / status / date range. Every email a Classic Automation OR a Customer Journey emits creates a campaign object, so this is the cleanest "what are my automations sending?" view.
- **`get_member_journey_events`** — wraps the member activity feed, filters server-side to actions matching `"automation"` or `"journey"`. Useful to surface which automation/journey emails a contact has received without scanning their full activity.
- **`get_automation_summary`** — combined overview: Classic workflow counts by status + recent automation send volume in a configurable lookback window (default 30 days). Designed as the audit entry point.

Tool count: **112 → 115**.

Also corrected `list_automations` docstring (it returns Classic only, not Customer Journeys, contrary to the previous doc) and expanded the README's Automations section to document the journey coverage gap honestly with pointers to the new workarounds.

## Test plan

- [x] `uv run pytest` — 67/67 tests pass in ~0.1s
- [x] `uv run ruff check src/ tests/` — clean
- [x] 4 new smoke tests : filter wiring, server-side action filtering on activity feed, multi-call aggregation in summary

## Notes

This release addresses [a known frustration](https://www.reddit.com/r/mcp/comments/1kg9jzh/) in the community: Mailchimp pushes users toward Customer Journeys in the UI but never opened a public read API for them. We're not magically reading the journey graph (impossible), but we are providing the recommended workarounds, documented as such.

After merge, tag `v0.6.0` to trigger the PyPI publish workflow automatically.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbgaDAfLrHxDmXVAW2f8MT)_