### PR TITLE
Add get_campaign_content read tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-24
+
+### Added
+- **`get_campaign_content`** — read tool returning a campaign's rendered body copy via
+  `GET /campaigns/{id}/content`. Fills the gap between `get_campaign_details` (settings)
+  and `set_campaign_content` (draft writes), which left no way to read the body of a sent
+  campaign. Returns `plain_text` by default, with `include_html` to opt into the raw HTML;
+  A/B (variate) campaigns return a per-variation breakdown. Registered as a read tool, so it
+  stays available under `MAILCHIMP_READ_ONLY=true`.
+
 ## [0.6.0] - 2026-05
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mailchimp-mcp"
-version = "0.6.0"
+version = "0.7.0"
 description = "MCP server for the Mailchimp Marketing API — access campaigns, audiences, reports, and more from any MCP-compatible client."
 readme = "README.md"
 license = "MIT"

--- a/src/mailchimp_mcp_server/server.py
+++ b/src/mailchimp_mcp_server/server.py
@@ -234,6 +234,57 @@ def get_campaign_details(campaign_id: str) -> str:
 
 
 @mcp.tool()
+def get_campaign_content(campaign_id: str, include_html: bool = False) -> str:
+    """Read the rendered body copy of a campaign (plain text, optionally HTML).
+
+    Use to retrieve the email copy that was actually sent, for content audits, analysis, or
+    repurposing. Use get_campaign_details for settings/metadata (subject line, sender) and
+    get_campaign_report for post-send performance. Use list_campaigns or search_campaigns to
+    find campaign IDs.
+
+    Authenticated via API key. Subject to Mailchimp API rate limits (max 10 concurrent requests). Read-only, safe to retry.
+
+    Args:
+        campaign_id: The Mailchimp campaign ID (e.g. 'abc123def4'). Obtain from list_campaigns
+            or search_campaigns. This is the API id, not the numeric web_id from the dashboard URL.
+        include_html: When True, also return the raw HTML body. Defaults to False so responses
+            stay compact; plain_text is enough for most content work.
+
+    Returns:
+        JSON with campaign_id and plain_text (the plain-text body); html is added only when
+        include_html=True. For A/B (variate) campaigns, a variations array is included with one
+        entry per content variation: {label, plain_text, and html when include_html=True}.
+        Returns error if the campaign_id is invalid or the campaign has no content.
+
+    Example:
+        get_campaign_content(campaign_id="abc123def4") -> {"campaign_id": "abc123def4", "plain_text": "Hi *|FNAME|* ..."}
+    """
+    data = mc_request(f"/campaigns/{campaign_id}/content")
+    if "error" in data:
+        return json.dumps(data, indent=2)
+
+    result = {
+        "campaign_id": campaign_id,
+        "plain_text": data.get("plain_text", ""),
+    }
+    if include_html:
+        result["html"] = data.get("html", "")
+
+    variations = data.get("variate_contents")
+    if variations:
+        result["variations"] = [
+            {
+                "label": variation.get("content_label", ""),
+                "plain_text": variation.get("plain_text", ""),
+                **({"html": variation.get("html", "")} if include_html else {}),
+            }
+            for variation in variations
+        ]
+
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
 def get_campaign_report(campaign_id: str) -> str:
     """Retrieve aggregate performance metrics for a sent campaign: opens, clicks, bounces, benchmarks.
 

--- a/tests/test_tools_smoke.py
+++ b/tests/test_tools_smoke.py
@@ -97,6 +97,43 @@ class TestCampaigns:
         assert "since_send_time" not in calls[0]["params"]
 
 
+class TestCampaignContent:
+    def test_returns_plain_text_and_withholds_html_by_default(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"plain_text": "Welcome aboard, here is your guide.", "html": "<p>Welcome</p>"})
+        payload = _parse(server.get_campaign_content(campaign_id="cam_1"))
+        assert calls[0]["endpoint"] == "/campaigns/cam_1/content"
+        assert calls[0]["method"] == "GET"
+        assert payload["campaign_id"] == "cam_1"
+        assert payload["plain_text"].startswith("Welcome aboard")
+        assert "html" not in payload
+
+    def test_includes_html_when_opted_in(self, mock_mc_request) -> None:
+        mock_mc_request({"plain_text": "Body copy", "html": "<p>Body copy</p>"})
+        payload = _parse(server.get_campaign_content(campaign_id="cam_1", include_html=True))
+        assert payload["html"] == "<p>Body copy</p>"
+
+    def test_breaks_out_ab_variations(self, mock_mc_request) -> None:
+        mock_mc_request(
+            {
+                "plain_text": "",
+                "variate_contents": [
+                    {"content_label": "Variation A", "plain_text": "Copy for A"},
+                    {"content_label": "Variation B", "plain_text": "Copy for B"},
+                ],
+            }
+        )
+        payload = _parse(server.get_campaign_content(campaign_id="cam_variate"))
+        assert len(payload["variations"]) == 2
+        assert payload["variations"][0]["label"] == "Variation A"
+        assert payload["variations"][1]["plain_text"] == "Copy for B"
+
+    def test_propagates_api_error(self, mock_mc_request) -> None:
+        mock_mc_request({"error": "Resource Not Found", "status": 404})
+        payload = _parse(server.get_campaign_content(campaign_id="missing"))
+        assert payload["error"] == "Resource Not Found"
+        assert "plain_text" not in payload
+
+
 class TestReports:
     def test_get_campaign_report_extracts_metrics(self, mock_mc_request) -> None:
         mock_mc_request(


### PR DESCRIPTION
## What

Adds `get_campaign_content`, a read-only tool that returns the rendered body copy of a campaign via `GET /campaigns/{id}/content`.

This closes a gap in the campaign tooling: we could read a campaign's settings (`get_campaign_details`) and write a draft body (`set_campaign_content`), but there was no way to **read the body of a sent campaign** for auditing, analysis, or repurposing.

## Behaviour

- Returns `plain_text` by default to keep responses compact
- `include_html=True` opts into the raw HTML body
- A/B (variate) campaigns return a `variations` array, one entry per content variation (`label`, `plain_text`, and `html` when requested)
- Propagates API errors instead of masking them
- No write path, so it stays available under `MAILCHIMP_READ_ONLY=true`

## Tests

4 new tests in `TestCampaignContent`: plain-text default, HTML opt-in, A/B variation parsing, error propagation. Full suite green (71 passed).

## Release

Version bumped to 0.7.0, CHANGELOG dated. Publishing to PyPI after merge.