### PR TITLE
feat: File Manager, Surveys, and Signup Forms tools (#14, #15, #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configured accounts. Single-key setups are unaffected and behave exactly as before.
 - **`list_accounts`** — read-only tool returning the configured account names and their
   read-only / dry-run state, for discovering valid `account` values. Never returns API keys.
+- **File Manager** (#14) — `list_files`, `get_file`, `upload_file` (base64), `delete_file`,
+  and `list_file_folders`, enabling programmatic image hosting for campaign and template content.
+- **Surveys** (#15) — `list_surveys`, `get_survey`, `publish_survey`, and `unpublish_survey`
+  for an audience's surveys.
+- **Signup forms** (#16) — `list_signup_forms` and `customize_signup_form` (header, contents,
+  and styles) for an audience's default signup form.
 
 ### Changed
-- Tool count bumped to **117** (was 115) — README and `glama.json` descriptions updated
-  accordingly. (The previous "115" headline trailed the actual count of 116; this corrects
-  it and adds `list_accounts`.)
+- Tool count bumped to **128** (was 115) — README and `glama.json` descriptions updated
+  accordingly. (The previous "115" headline trailed the actual count of 116; this adds
+  multi-account `list_accounts`, File Manager, Surveys, and Signup forms.)
+
+### Fixed
+- Account selectors are now matched case-insensitively — a capitalized `account`
+  (e.g. `"Marketing"`, `"Default"`) resolves to the configured account instead of erroring,
+  matching how account names are lowercased when the registry is built.
 
 ## [0.7.0] - 2026-06-24
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![MCP](https://img.shields.io/badge/MCP-compatible-green.svg)](https://modelcontextprotocol.io)
 
-The most complete [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/) — **117 tools** to query and manage your Mailchimp account from any MCP-compatible client, with A/B campaign support, geographic reporting, full landing-page lifecycle, CRM-style member notes, e-commerce carts and promo codes, Classic Automation + Customer Journey reporting, and read-only / dry-run safety modes.
+The most complete [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/) — **128 tools** to query and manage your Mailchimp account from any MCP-compatible client, with A/B campaign support, geographic reporting, full landing-page lifecycle, CRM-style member notes, e-commerce carts and promo codes, Classic Automation + Customer Journey reporting, and read-only / dry-run safety modes.
 
 Uses the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/api/) via [`requests`](https://pypi.org/project/requests/). Not based on the official [mailchimp-marketing-python](https://github.com/mailchimp/mailchimp-marketing-python) client. I hit too many issues with it so I went with raw HTTP calls instead.
 
@@ -33,6 +33,9 @@ Uses the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/api
 - **Automations** - List workflows, inspect emails in a workflow, view queues
 - **Templates** - Browse templates and extract HTML content
 - **Landing pages** - List and inspect landing pages
+- **File Manager** - Browse stored images and files, and folders
+- **Surveys** - List and inspect an audience's surveys
+- **Signup forms** - Inspect an audience's signup forms
 - **E-commerce** - Stores, orders, products, customers (requires e-commerce integration)
 - **Campaign folders** - Browse folder organization
 - **Batch operations** - Monitor bulk operation status
@@ -46,6 +49,9 @@ Uses the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/api
 - **Interest categories** - Create and delete categories and interests
 - **Webhooks** - Create and delete webhooks
 - **Templates** - Create, update, and delete email templates
+- **File Manager** - Upload (base64) and delete images and files
+- **Surveys** - Publish and unpublish audience surveys
+- **Signup forms** - Customize header, contents, and styles
 - **Automations** - Pause and start automation workflows
 - **E-commerce** - Cart lifecycle, promo rules, and promo codes for discount workflows
 - **Batch** - Run bulk API operations in a single request
@@ -372,6 +378,32 @@ Replace `mcp-cli` with your client's binary name. For read-only mode, add
 | `delete_landing_page` | Permanently delete a landing page |
 | `publish_landing_page` | Publish a landing page to its public URL |
 | `unpublish_landing_page` | Take a published landing page offline |
+
+### File Manager
+
+| Tool | Description |
+|---|---|
+| `list_files` | List images and files stored in the File Manager |
+| `get_file` | Get a single file's metadata and hosted URL |
+| `upload_file` | Upload a new image or file (base64-encoded) |
+| `delete_file` | Permanently delete a file |
+| `list_file_folders` | List File Manager folders |
+
+### Surveys
+
+| Tool | Description |
+|---|---|
+| `list_surveys` | List an audience's surveys with status and public URL |
+| `get_survey` | Get a single survey's full details |
+| `publish_survey` | Publish a survey to its public URL |
+| `unpublish_survey` | Take a published survey offline |
+
+### Signup Forms
+
+| Tool | Description |
+|---|---|
+| `list_signup_forms` | Get the signup forms configured for an audience |
+| `customize_signup_form` | Customize a signup form's header, contents, and styles |
 
 ### E-commerce
 

--- a/glama.json
+++ b/glama.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "mailchimp-mcp",
-  "description": "MCP server for the Mailchimp Marketing API. 117 tools for managing campaigns, audiences, members, templates, segments, Classic Automations and Customer Journey workarounds, reports, e-commerce (carts, promo rules and codes), A/B testing, landing pages, CRM notes, multi-account support, and more.",
+  "description": "MCP server for the Mailchimp Marketing API. 128 tools for managing campaigns, audiences, members, templates, segments, Classic Automations and Customer Journey workarounds, reports, e-commerce (carts, promo rules and codes), A/B testing, landing pages, CRM notes, multi-account support, File Manager, surveys, signup forms, and more.",
   "author": {
     "name": "Damien Tilman",
     "url": "https://github.com/damientilman"

--- a/src/mailchimp_mcp_server/server.py
+++ b/src/mailchimp_mcp_server/server.py
@@ -77,8 +77,11 @@ def _resolve_account(account: Optional[str]) -> dict:
     account -- so single-key setups and the existing test monkeypatches behave exactly
     as before. A named account is looked up in MAILCHIMP_ACCOUNTS. Unknown names return
     an {"error": ...} dict listing the available accounts. account=None never auto-routes
-    to a named account, even if only one is configured.
+    to a named account, even if only one is configured. Selectors are matched
+    case-insensitively, since account names are lowercased when the registry is built.
     """
+    if account is not None:
+        account = account.lower()
     if account is None or account == DEFAULT_ACCOUNT:
         return {
             "name": DEFAULT_ACCOUNT,
@@ -4512,6 +4515,326 @@ def trigger_customer_journey(journey_id: str, step_id: str, email_address: str, 
         account=account,
     )
     return json.dumps({"status": "triggered", "journey_id": journey_id, "step_id": step_id, "email_address": email_address}, indent=2)
+
+
+@mcp.tool()
+def list_files(count: int = 10, offset: int = 0, type: Optional[str] = None, account: str | None = None) -> str:
+    """List images and files stored in the account's File Manager.
+
+    Use to discover file_id and hosted URLs for embedding images in campaign or template
+    content. Use get_file for one file's full metadata, upload_file to add a new one, and
+    list_file_folders to browse the folder structure.
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+
+    Args:
+        count: Files to return (1-1000, default 10).
+        offset: Pagination offset. Use when total_items exceeds count.
+        type: Optional media type filter. Either 'image' or 'file' (non-image). Omit for all.
+        account: Optional account name (e.g. 'marketing') configured via MAILCHIMP_API_KEY_<NAME>. Omit to use the default account. See list_accounts.
+
+    Returns:
+        JSON with total_items and files array. Each file: id (use as file_id), name, type
+        ('image' or 'file'), full_size_url (hosted URL for embedding), thumbnail_url, size
+        (bytes), width, height, folder_id, created_at, created_by.
+    """
+    params: dict = {"count": count, "offset": offset}
+    if type:
+        params["type"] = type
+    data = mc_request("/file-manager/files", params=params, account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    files = []
+    for f in data.get("files", []):
+        files.append({
+            "id": f.get("id"),
+            "name": f.get("name"),
+            "type": f.get("type"),
+            "full_size_url": f.get("full_size_url"),
+            "thumbnail_url": f.get("thumbnail_url"),
+            "size": f.get("size"),
+            "width": f.get("width"),
+            "height": f.get("height"),
+            "folder_id": f.get("folder_id"),
+            "created_at": f.get("created_at"),
+            "created_by": f.get("created_by"),
+        })
+    return json.dumps({"total_items": data.get("total_items"), "files": files}, indent=2)
+
+
+@mcp.tool()
+def get_file(file_id: str, account: str | None = None) -> str:
+    """Retrieve full metadata for a single File Manager file.
+
+    Use when you have a file_id (from list_files) and need its hosted URL, dimensions, or
+    folder. Use list_files to browse and discover file_ids.
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+    Returns 404 error if file_id is invalid.
+
+    Args:
+        file_id: File ID (numeric, as a string) from list_files.
+        account: Optional account name (e.g. 'marketing') configured via MAILCHIMP_API_KEY_<NAME>. Omit to use the default account. See list_accounts.
+
+    Returns:
+        JSON with id, name, type, full_size_url, thumbnail_url, size, width, height,
+        folder_id, created_at, created_by.
+    """
+    data = mc_request(f"/file-manager/files/{file_id}", account=account)
+    return json.dumps(data, indent=2)
+
+
+@mcp.tool()
+def upload_file(name: str, file_data: str, folder_id: Optional[str] = None, account: str | None = None) -> str:
+    """Upload a new image or file to the File Manager (base64-encoded).
+
+    Enables programmatic image hosting for campaign and template content: upload here, then
+    reference the returned full_size_url in your HTML. Use list_file_folders to target a
+    folder, list_files to browse existing files, and delete_file to remove one.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+
+    Args:
+        name: File name including extension (e.g. 'hero.png'). Shown in the File Manager.
+        file_data: The file content, base64-encoded (not a URL or raw bytes).
+        folder_id: Optional folder ID (from list_file_folders) to upload into. Omit for the root.
+        account: Optional account name (e.g. 'marketing') configured via MAILCHIMP_API_KEY_<NAME>. Omit to use the default account. See list_accounts.
+
+    Returns:
+        JSON with id (use as file_id), name, type, full_size_url (hosted URL for embedding),
+        thumbnail_url, size, width, height, folder_id, created_at.
+    """
+    if (guard := _guard_write(action="upload file", name=name, folder_id=folder_id, account=account)):
+        return guard
+    body: dict = {"name": name, "file_data": file_data}
+    if folder_id:
+        body["folder_id"] = int(folder_id)
+    data = mc_request("/file-manager/files", body=body, method="POST", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    return json.dumps({
+        "id": data.get("id"),
+        "name": data.get("name"),
+        "type": data.get("type"),
+        "full_size_url": data.get("full_size_url"),
+        "thumbnail_url": data.get("thumbnail_url"),
+        "size": data.get("size"),
+        "width": data.get("width"),
+        "height": data.get("height"),
+        "folder_id": data.get("folder_id"),
+        "created_at": data.get("created_at"),
+    }, indent=2)
+
+
+@mcp.tool()
+def delete_file(file_id: str, account: str | None = None) -> str:
+    """Permanently delete a file from the File Manager.
+
+    Irreversible. Any campaign or template still referencing the file's hosted URL will show a
+    broken image afterwards. Use list_files to find the file_id and get_file to confirm the
+    target before deleting.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+
+    Args:
+        file_id: File ID (numeric, as a string) from list_files.
+        account: Optional account name (e.g. 'marketing') configured via MAILCHIMP_API_KEY_<NAME>. Omit to use the default account. See list_accounts.
+
+    Returns:
+        JSON with status 'success' on deletion, or an error object if file_id is invalid.
+    """
+    if (guard := _guard_write(action="delete file", file_id=file_id, account=account)):
+        return guard
+    data = mc_request(f"/file-manager/files/{file_id}", method="DELETE", account=account)
+    return json.dumps(data, indent=2)
+
+
+@mcp.tool()
+def list_file_folders(count: int = 10, offset: int = 0, account: str | None = None) -> str:
+    """List folders in the account's File Manager.
+
+    Use to discover folder_id values for organizing or targeting uploads via upload_file. Use
+    list_files to see the files themselves.
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+
+    Args:
+        count: Folders to return (1-1000, default 10).
+        offset: Pagination offset. Use when total_items exceeds count.
+        account: Optional account name (e.g. 'marketing') configured via MAILCHIMP_API_KEY_<NAME>. Omit to use the default account. See list_accounts.
+
+    Returns:
+        JSON with total_items and folders array. Each folder: id (use as folder_id), name,
+        file_count, created_at, created_by.
+    """
+    data = mc_request("/file-manager/folders", params={"count": count, "offset": offset}, account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    folders = []
+    for fo in data.get("folders", []):
+        folders.append({
+            "id": fo.get("id"),
+            "name": fo.get("name"),
+            "file_count": fo.get("file_count"),
+            "created_at": fo.get("created_at"),
+            "created_by": fo.get("created_by"),
+        })
+    return json.dumps({"total_items": data.get("total_items"), "folders": folders}, indent=2)
+
+
+@mcp.tool()
+def list_surveys(list_id: str, account: str | None = None) -> str:
+    """List all surveys for an audience with their status and public URL.
+
+    Use to discover survey_id values and see which surveys are live. Use get_survey for one
+    survey's full detail, and publish_survey / unpublish_survey to change its live state.
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+    Returns 404 error if list_id is invalid.
+
+    Args:
+        list_id: Audience/list ID (from list_audiences).
+        account: Optional account name (e.g. 'marketing') configured via MAILCHIMP_API_KEY_<NAME>. Omit to use the default account. See list_accounts.
+
+    Returns:
+        JSON with total_items and surveys array. Each survey typically includes id (use as
+        survey_id), title, status ('draft', 'published', or 'unpublished'), url (public survey
+        URL), created_at, updated_at.
+    """
+    data = mc_request(f"/lists/{list_id}/surveys", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    return json.dumps({"total_items": data.get("total_items"), "surveys": data.get("surveys", [])}, indent=2)
+
+
+@mcp.tool()
+def get_survey(list_id: str, survey_id: str, account: str | None = None) -> str:
+    """Retrieve full details for a single survey.
+
+    Use when you have a survey_id (from list_surveys) and need its questions, status, or public
+    URL. Use publish_survey / unpublish_survey to change whether it is live.
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+    Returns 404 error if list_id or survey_id is invalid.
+
+    Args:
+        list_id: Audience/list ID (from list_audiences).
+        survey_id: Survey ID (from list_surveys).
+        account: Optional account name (e.g. 'marketing') configured via MAILCHIMP_API_KEY_<NAME>. Omit to use the default account. See list_accounts.
+
+    Returns:
+        JSON survey object including id, title, status, url, questions, created_at, updated_at.
+    """
+    data = mc_request(f"/lists/{list_id}/surveys/{survey_id}", account=account)
+    return json.dumps(data, indent=2)
+
+
+@mcp.tool()
+def publish_survey(list_id: str, survey_id: str, account: str | None = None) -> str:
+    """Publish a survey, making it live at its public URL.
+
+    Works for surveys in draft, unpublished, or previously-published-then-edited state. Use
+    list_surveys to find the survey_id and check its status. Use unpublish_survey to take it
+    back down.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+
+    Args:
+        list_id: Audience/list ID (from list_audiences).
+        survey_id: Survey ID (from list_surveys).
+        account: Optional account name (e.g. 'marketing') configured via MAILCHIMP_API_KEY_<NAME>. Omit to use the default account. See list_accounts.
+
+    Returns:
+        JSON with status 'published' and the survey_id, or an error object.
+    """
+    if (guard := _guard_write(action="publish survey", list_id=list_id, survey_id=survey_id, account=account)):
+        return guard
+    data = mc_request(f"/lists/{list_id}/surveys/{survey_id}/actions/publish", method="POST", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    return json.dumps({"status": "published", "survey_id": survey_id}, indent=2)
+
+
+@mcp.tool()
+def unpublish_survey(list_id: str, survey_id: str, account: str | None = None) -> str:
+    """Unpublish a survey that is currently live, taking it offline.
+
+    Use list_surveys to find the survey_id and confirm it is published. Use publish_survey to
+    put it back live.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+
+    Args:
+        list_id: Audience/list ID (from list_audiences).
+        survey_id: Survey ID (from list_surveys).
+        account: Optional account name (e.g. 'marketing') configured via MAILCHIMP_API_KEY_<NAME>. Omit to use the default account. See list_accounts.
+
+    Returns:
+        JSON with status 'unpublished' and the survey_id, or an error object.
+    """
+    if (guard := _guard_write(action="unpublish survey", list_id=list_id, survey_id=survey_id, account=account)):
+        return guard
+    data = mc_request(f"/lists/{list_id}/surveys/{survey_id}/actions/unpublish", method="POST", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
+    return json.dumps({"status": "unpublished", "survey_id": survey_id}, indent=2)
+
+
+@mcp.tool()
+def list_signup_forms(list_id: str, account: str | None = None) -> str:
+    """Get the signup forms (header, body content, and styles) configured for an audience.
+
+    Use to inspect the current hosted and embedded signup forms before changing them with
+    customize_signup_form.
+
+    Authenticated via API key. Max 10 concurrent requests. Read-only, safe to retry.
+    Returns 404 error if list_id is invalid.
+
+    Args:
+        list_id: Audience/list ID (from list_audiences).
+        account: Optional account name (e.g. 'marketing') configured via MAILCHIMP_API_KEY_<NAME>. Omit to use the default account. See list_accounts.
+
+    Returns:
+        JSON with signup_forms array. Each entry has header (object), contents (array of
+        {section, value}), styles (array of {section, options}), and signup_form_url.
+    """
+    data = mc_request(f"/lists/{list_id}/signup-forms", account=account)
+    return json.dumps(data, indent=2)
+
+
+@mcp.tool()
+def customize_signup_form(list_id: str, header: Optional[dict] = None, contents: Optional[list] = None, styles: Optional[list] = None, account: str | None = None) -> str:
+    """Customize an audience's default signup form (header, content sections, and styles).
+
+    At least one of header, contents, or styles must be provided. Use list_signup_forms first
+    to inspect the current form and mirror its structure.
+
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+
+    Args:
+        list_id: Audience/list ID (from list_audiences).
+        header: Optional header object, e.g. {"image_url": "...", "text": "...", "background_color": "..."}.
+        contents: Optional array of content sections, each {"section": <name>, "value": <html>}.
+            Section names include 'signup_message', 'unsub_message', 'signup_thank_you_title'.
+        styles: Optional array of style sections, each {"section": <name>, "options": [{"property": <name>, "value": <val>}]}.
+        account: Optional account name (e.g. 'marketing') configured via MAILCHIMP_API_KEY_<NAME>. Omit to use the default account. See list_accounts.
+
+    Returns:
+        JSON with the updated signup form configuration, or an error object.
+    """
+    body: dict = {}
+    if header is not None:
+        body["header"] = header
+    if contents is not None:
+        body["contents"] = contents
+    if styles is not None:
+        body["styles"] = styles
+    if not body:
+        return json.dumps({"error": "Provide at least one of header, contents, or styles to customize."}, indent=2)
+    if (guard := _guard_write(action="customize signup form", list_id=list_id, account=account)):
+        return guard
+    data = mc_request(f"/lists/{list_id}/signup-forms", body=body, method="POST", account=account)
+    return json.dumps(data, indent=2)
 
 
 def main():

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -89,6 +89,19 @@ class TestResolveAccount:
         assert "default" in resolved["error"]
         assert "tts" in resolved["error"]
 
+    def test_selector_is_case_insensitive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Names are lowercased when the registry is built, so resolution must match
+        # case-insensitively; a capitalized selector still routes to the account.
+        monkeypatch.setattr(server, "MAILCHIMP_API_KEY", "live-us1")
+        monkeypatch.setattr(
+            server,
+            "MAILCHIMP_ACCOUNTS",
+            {"marketing": {"api_key": "k-us5", "dc": "us5", "base_url": "https://us5.api.mailchimp.com/3.0", "read_only": False, "dry_run": False}},
+        )
+        assert server._resolve_account("Marketing")["name"] == "marketing"
+        assert server._resolve_account("MARKETING")["api_key"] == "k-us5"
+        assert server._resolve_account("Default")["name"] == "default"
+
     def test_available_names_includes_default_only_when_key_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(server, "MAILCHIMP_ACCOUNTS", {"tts": {"read_only": False, "dry_run": False}})
         monkeypatch.setattr(server, "MAILCHIMP_API_KEY", "live-us1")

--- a/tests/test_tools_smoke.py
+++ b/tests/test_tools_smoke.py
@@ -833,3 +833,126 @@ class TestAccounts:
             server.list_audiences(account="foo")
         assert mock_req.call_args.args[1].startswith("https://us9.api.mailchimp.com/3.0/")
         assert mock_req.call_args.kwargs["auth"] == ("anystring", "fookey-us9")
+
+
+class TestFileManager:
+    def test_list_files_extracts_fields(self, mock_mc_request) -> None:
+        calls = mock_mc_request(
+            {
+                "total_items": 1,
+                "files": [
+                    {
+                        "id": 7,
+                        "name": "hero.png",
+                        "type": "image",
+                        "full_size_url": "https://cdn/hero.png",
+                        "thumbnail_url": "https://cdn/t.png",
+                        "size": 1024,
+                        "width": 600,
+                        "height": 400,
+                        "folder_id": 3,
+                        "created_at": "2024-01-01T00:00:00Z",
+                        "created_by": "user",
+                    }
+                ],
+            }
+        )
+        payload = _parse(server.list_files(type="image"))
+        assert payload["total_items"] == 1
+        assert payload["files"][0]["id"] == 7
+        assert payload["files"][0]["full_size_url"].endswith("hero.png")
+        assert calls[0]["params"]["type"] == "image"
+
+    def test_upload_file_dispatch(self, mock_mc_request) -> None:
+        calls = mock_mc_request(
+            {
+                "id": 9,
+                "name": "a.png",
+                "type": "image",
+                "full_size_url": "u",
+                "thumbnail_url": "t",
+                "size": 1,
+                "width": 1,
+                "height": 1,
+                "folder_id": 3,
+                "created_at": "z",
+            }
+        )
+        payload = _parse(server.upload_file(name="a.png", file_data="Zm9v", folder_id="3"))
+        assert payload["id"] == 9
+        assert calls[0]["method"] == "POST"
+        assert calls[0]["endpoint"] == "/file-manager/files"
+        assert calls[0]["body"]["file_data"] == "Zm9v"
+        assert calls[0]["body"]["folder_id"] == 3
+
+    def test_delete_file_dispatch(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"status": "success"})
+        payload = _parse(server.delete_file(file_id="7"))
+        assert payload["status"] == "success"
+        assert calls[0]["method"] == "DELETE"
+        assert calls[0]["endpoint"] == "/file-manager/files/7"
+
+    def test_list_file_folders_extracts_fields(self, mock_mc_request) -> None:
+        mock_mc_request(
+            {"total_items": 1, "folders": [{"id": 3, "name": "Campaigns", "file_count": 12, "created_at": "z", "created_by": "u"}]}
+        )
+        payload = _parse(server.list_file_folders())
+        assert payload["folders"][0]["id"] == 3
+        assert payload["folders"][0]["file_count"] == 12
+
+
+class TestSurveys:
+    def test_list_surveys_dispatch(self, mock_mc_request) -> None:
+        calls = mock_mc_request(
+            {"total_items": 1, "surveys": [{"id": "s1", "title": "NPS", "status": "published", "url": "https://x"}]}
+        )
+        payload = _parse(server.list_surveys(list_id="abc"))
+        assert payload["surveys"][0]["id"] == "s1"
+        assert calls[0]["endpoint"] == "/lists/abc/surveys"
+
+    def test_publish_survey_dispatch(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"status": "success"})
+        payload = _parse(server.publish_survey(list_id="abc", survey_id="s1"))
+        assert payload["status"] == "published"
+        assert calls[0]["method"] == "POST"
+        assert calls[0]["endpoint"] == "/lists/abc/surveys/s1/actions/publish"
+
+    def test_unpublish_survey_dispatch(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"status": "success"})
+        payload = _parse(server.unpublish_survey(list_id="abc", survey_id="s1"))
+        assert payload["status"] == "unpublished"
+        assert calls[0]["endpoint"] == "/lists/abc/surveys/s1/actions/unpublish"
+
+
+class TestSignupForms:
+    def test_list_signup_forms_dispatch(self, mock_mc_request) -> None:
+        calls = mock_mc_request(
+            {"signup_forms": [{"signup_form_url": "https://x", "header": {}, "contents": [], "styles": []}]}
+        )
+        payload = _parse(server.list_signup_forms(list_id="abc"))
+        assert payload["signup_forms"][0]["signup_form_url"] == "https://x"
+        assert calls[0]["endpoint"] == "/lists/abc/signup-forms"
+
+    def test_customize_signup_form_dispatch(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"signup_forms": []})
+        server.customize_signup_form(
+            list_id="abc", contents=[{"section": "signup_message", "value": "<p>Hi</p>"}]
+        )
+        assert calls[0]["method"] == "POST"
+        assert calls[0]["endpoint"] == "/lists/abc/signup-forms"
+        assert calls[0]["body"]["contents"][0]["section"] == "signup_message"
+
+    def test_customize_signup_form_requires_a_field(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"signup_forms": []})
+        payload = _parse(server.customize_signup_form(list_id="abc"))
+        assert "error" in payload
+        assert calls == [], "no request should be dispatched when nothing is provided"
+
+    def test_upload_file_dry_run_previews(self, monkeypatch: pytest.MonkeyPatch, mock_mc_request) -> None:
+        monkeypatch.setattr(server, "DRY_RUN", True)
+        calls = mock_mc_request({"should": "not-be-called"})
+        payload = _parse(server.upload_file(name="a.png", file_data="Zm9v"))
+        assert payload["dry_run"] is True
+        assert payload["action"] == "upload file"
+        assert "file_data" not in payload, "raw file data must not leak into the dry-run preview"
+        assert calls == []


### PR DESCRIPTION
## What
Expands native Mailchimp coverage with **11 new tools** (117 → 128), closing the three remaining feature issues. Every new tool threads the per-call `account` argument from multi-account support, so the AST coverage test stays green.

### File Manager (#14)
- `list_files`, `get_file`, `upload_file` (base64), `delete_file`, `list_file_folders`
- Enables programmatic image hosting for campaign and template content.

### Surveys (#15)
- `list_surveys`, `get_survey`, `publish_survey`, `unpublish_survey`

### Signup Forms (#16)
- `list_signup_forms`, `customize_signup_form` (header, contents, styles)
- Note: Mailchimp's customize endpoint is `POST` (the issue said `PUT`); implemented as `POST`.

## Also fixed
- **Case-insensitive account selection** — a capitalized `account` (e.g. `"Marketing"`, `"Default"`) now resolves to the configured account instead of erroring, matching how names are lowercased at load. Surfaced by the post-merge review of #41.

## Safety & conventions
- All write tools (`upload_file`, `delete_file`, `publish_survey`, `unpublish_survey`, `customize_signup_form`) respect read-only / dry-run; the dry-run preview never includes raw `file_data`.
- New read tools propagate unknown-account / API errors instead of masking them as empty results.
- Docstrings, `account` threading, and `account:` docs follow the existing convention.

## Tests
- 12 new tests (dispatch/field extraction for each family, dry-run preview, empty-body guard, case-insensitive resolution). Full suite: **109 passed**, `ruff` clean.

Closes #14
Closes #15
Closes #16