### PR TITLE
feat: runtime security guardrails (risk metadata, audit log, arg validation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Runtime security guardrails** (#36) — server-side signals a runtime-security gateway can
+  enforce on, following the defense-in-depth split discussed in the community thread:
+  - **Machine-readable risk metadata** — every tool is classified `read` / `write` /
+    `destructive` (irreversible data loss or an irreversible send). Exposed both as
+    MCP-standard tool annotations (`readOnlyHint` / `destructiveHint` / `idempotentHint`) via
+    `tools/list` and through a new **`describe_tools`** read tool (per-tool risk + tier counts).
+  - **Structured audit log** — `MAILCHIMP_AUDIT_LOG=true` emits one JSON event per dispatch to
+    stderr (tool, risk tier, destructive flag, account, outcome, inspected args) from the two
+    chokepoints; bulky/sensitive values (e.g. `file_data`) are redacted, response bodies never
+    logged. Off by default with zero overhead.
+  - **Argument-contract validation** — `mc_request` rejects out-of-range `count` (must be
+    1–1000) and missing path IDs before dispatch, and the dry-run preview now carries the
+    tool's risk tier.
 - **Multi-account support** (#37) — configure additional Mailchimp accounts with
   `MAILCHIMP_API_KEY_<NAME>` environment variables (the plain `MAILCHIMP_API_KEY`
   remains the implicit `default`). Every tool gains an optional `account` argument to
@@ -43,9 +56,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   writes target custom/headless storefronts (Shopify/WooCommerce sync automatically).
 
 ### Changed
-- Tool count bumped to **226** (was 115) — README and `glama.json` descriptions updated
+- Tool count bumped to **227** (was 115) — README and `glama.json` descriptions updated
   accordingly. Adds multi-account, File Manager, Surveys, Signup forms, Verified Domains,
-  reporting depth, deliverability, automation controls, and full e-commerce writes.
+  reporting depth, deliverability, automation controls, full e-commerce writes, and the
+  `describe_tools` risk-metadata tool.
 
 ### Fixed
 - Account selectors are now matched case-insensitively — a capitalized `account`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![MCP](https://img.shields.io/badge/MCP-compatible-green.svg)](https://modelcontextprotocol.io)
 
-The most complete [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/) — **226 tools** to query and manage your Mailchimp account from any MCP-compatible client, with A/B campaign support, geographic reporting, full landing-page lifecycle, CRM-style member notes, e-commerce carts and promo codes, Classic Automation + Customer Journey reporting, and read-only / dry-run safety modes.
+The most complete [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/) — **227 tools** to query and manage your Mailchimp account from any MCP-compatible client, with A/B campaign support, geographic reporting, full landing-page lifecycle, CRM-style member notes, e-commerce carts and promo codes, Classic Automation + Customer Journey reporting, and read-only / dry-run safety modes.
 
 Uses the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/api/) via [`requests`](https://pypi.org/project/requests/). Not based on the official [mailchimp-marketing-python](https://github.com/mailchimp/mailchimp-marketing-python) client. I hit too many issues with it so I went with raw HTTP calls instead.
 
@@ -56,6 +56,11 @@ Uses the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/api
 - **E-commerce** - Cart lifecycle, promo rules, and promo codes for discount workflows
 - **Batch** - Run bulk API operations in a single request
 
+**Runtime security**
+- **Risk metadata** - Per-tool read / write / destructive classification via MCP annotations and `describe_tools`
+- **Audit log** - Optional structured JSON audit events per dispatch (`MAILCHIMP_AUDIT_LOG`)
+- **Argument validation** - Pagination caps and required-ID checks before every request
+
 ## Prerequisites
 
 - Python 3.10+
@@ -103,6 +108,7 @@ pip install -e .
 | `MAILCHIMP_API_KEY_<NAME>` | No | API key for an additional named account (e.g. `MAILCHIMP_API_KEY_MARKETING`). Target it with the `account` argument. See [Multi-account](#multi-account). |
 | `MAILCHIMP_READ_ONLY_<NAME>` | No | Read-only mode for a specific named account (default: `false`) |
 | `MAILCHIMP_DRY_RUN_<NAME>` | No | Dry-run mode for a specific named account (default: `false`) |
+| `MAILCHIMP_AUDIT_LOG` | No | Set to `true` to emit a structured JSON audit event per tool dispatch to stderr (default: `false`). See [Runtime security](#runtime-security). |
 
 The datacenter (`us8`, `us21`, etc.) is automatically extracted from each key.
 
@@ -110,7 +116,20 @@ The datacenter (`us8`, `us21`, etc.) is automatically extracted from each key.
 
 **Read-only mode** — When `MAILCHIMP_READ_ONLY=true`, all write tools (create, update, delete, schedule, etc.) are blocked and return an error. Read tools work normally. This is the recommended default for shared or exploratory setups where you only need reporting and analytics.
 
-**Dry-run mode** — When `MAILCHIMP_DRY_RUN=true`, write tools return a preview of the action they *would* perform (tool name, target resource, parameters) without making any API call. Useful for testing prompts before going live.
+**Dry-run mode** — When `MAILCHIMP_DRY_RUN=true`, write tools return a preview of the action they *would* perform (tool name, target resource, parameters, and its risk tier) without making any API call. Useful for testing prompts before going live.
+
+### Runtime security
+
+The server is designed for defense-in-depth alongside an external MCP gateway: it owns the *semantics* (which tools are reads, reversible writes, or irreversible) and exposes them as machine-readable signals a gateway can enforce on, rather than making the gateway guess which calls are dangerous.
+
+**Risk metadata** — Every tool is classified as `read`, `write`, or `destructive` (irreversible data loss or an irreversible send). This surfaces two ways:
+
+- **MCP tool annotations** — `readOnlyHint`, `destructiveHint`, and `idempotentHint` travel through the standard `tools/list`, so any compliant client or gateway reads them directly.
+- **`describe_tools`** — a read tool returning `{name, risk, read_only, destructive, idempotent}` for every tool plus per-tier counts, for gateways that prefer a tool call.
+
+**Structured audit log** — With `MAILCHIMP_AUDIT_LOG=true`, each dispatch emits one JSON event to stderr with the tool, its risk tier, the `destructive` flag, the target account, the outcome (`executed` / `blocked_read_only` / `dry_run`), and the inspected arguments. Bulky or sensitive values (e.g. base64 `file_data`) are redacted and response bodies are never logged, so the stream is a safe audit sink to tail centrally.
+
+**Argument-contract validation** — All writes funnel through a single `_guard_write` chokepoint, and every request is validated before dispatch (pagination `count` capped to 1–1000, missing path IDs rejected), so malformed calls fail fast and consistently instead of hitting the API.
 
 ### Multi-account
 
@@ -217,6 +236,7 @@ Replace `mcp-cli` with your client's binary name. For read-only mode, add
 |---|---|
 | `get_account_info` | Get account name, email, and subscriber count |
 | `list_accounts` | List configured accounts and their read-only / dry-run state (for multi-account setups) |
+| `describe_tools` | List every tool with its risk tier (read / write / destructive) for policy enforcement |
 
 ### Campaigns (read)
 

--- a/glama.json
+++ b/glama.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "mailchimp-mcp",
-  "description": "MCP server for the Mailchimp Marketing API. 226 tools for managing campaigns, audiences, members, templates, segments, Classic Automations and Customer Journey workarounds, reports, e-commerce (carts, promo rules and codes), A/B testing, landing pages, CRM notes, multi-account support, File Manager, surveys, signup forms, verified domains, deliverability, full e-commerce writes, and more.",
+  "description": "MCP server for the Mailchimp Marketing API. 227 tools for managing campaigns, audiences, members, templates, segments, Classic Automations and Customer Journey workarounds, reports, e-commerce (carts, promo rules and codes), A/B testing, landing pages, CRM notes, multi-account support, File Manager, surveys, signup forms, verified domains, deliverability, full e-commerce writes, and more.",
   "author": {
     "name": "Damien Tilman",
     "url": "https://github.com/damientilman"

--- a/src/mailchimp_mcp_server/server.py
+++ b/src/mailchimp_mcp_server/server.py
@@ -1,10 +1,13 @@
 import hashlib
 import json
 import os
+import sys
+from datetime import datetime, timezone
 from typing import Optional
 
 import requests
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 # --- Config ---
 # The plain MAILCHIMP_API_KEY is the implicit "default" account. It is served from
@@ -15,8 +18,21 @@ MAILCHIMP_DC = MAILCHIMP_API_KEY.split("-")[-1] if "-" in MAILCHIMP_API_KEY else
 MAILCHIMP_BASE_URL = f"https://{MAILCHIMP_DC}.api.mailchimp.com/3.0"
 READ_ONLY = os.environ.get("MAILCHIMP_READ_ONLY", "").lower() in ("1", "true", "yes")
 DRY_RUN = os.environ.get("MAILCHIMP_DRY_RUN", "").lower() in ("1", "true", "yes")
+# When MAILCHIMP_AUDIT_LOG is truthy, every tool dispatch emits a structured JSON audit
+# event to stderr (see _emit_audit). Off by default; zero overhead when disabled.
+AUDIT_LOG = os.environ.get("MAILCHIMP_AUDIT_LOG", "").lower() in ("1", "true", "yes")
 
 DEFAULT_ACCOUNT = "default"
+
+# Machine-readable risk tier per tool name ('read' | 'write' | 'destructive'), populated at
+# import by _apply_tool_annotations(). Consumed by the audit layer, the dry-run preview, and
+# the describe_tools introspection tool. Also mirrored into MCP-standard tool annotations
+# (readOnlyHint / destructiveHint / idempotentHint) so a runtime-security gateway can enforce
+# policy on the destructive signal via tools/list instead of guessing which calls are dangerous.
+TOOL_RISK: dict = {}
+
+# Params whose values are bulky or sensitive and must not appear verbatim in audit events.
+_AUDIT_REDACT = frozenset({"file_data"})
 
 
 def _truthy(value: str) -> bool:
@@ -103,20 +119,66 @@ def _resolve_account(account: Optional[str]) -> dict:
     }
 
 
+def _caller_tool() -> Optional[str]:
+    """Name of the @mcp.tool() function that invoked the current chokepoint, if it is a tool.
+
+    Frame layout: 0 = this function, 1 = the chokepoint (_guard_write / mc_request), 2 = the
+    tool. Returns None when the caller is not a registered tool (e.g. internal use or an
+    unknown frame), so audit and risk lookups degrade gracefully.
+    """
+    try:
+        name = sys._getframe(2).f_code.co_name
+    except ValueError:
+        return None
+    return name if name in TOOL_RISK else None
+
+
+def _emit_audit(tool_name: Optional[str], outcome: str, **fields) -> None:
+    """Emit one structured JSON audit event to stderr (no-op unless MAILCHIMP_AUDIT_LOG is on).
+
+    Events carry the tool, its risk tier, the outcome ('executed' / 'blocked_read_only' /
+    'dry_run' / 'error'), the target account, and the inspected call arguments. Bulky or
+    sensitive param values (see _AUDIT_REDACT) are redacted; response bodies are never logged.
+    A gateway can tail this stream as a tamper-evident audit sink.
+    """
+    if not AUDIT_LOG:
+        return
+    event: dict = {
+        "audit": "mailchimp-mcp-server",
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "tool": tool_name,
+        "risk": TOOL_RISK.get(tool_name),
+        "destructive": TOOL_RISK.get(tool_name) == "destructive",
+        "outcome": outcome,
+    }
+    for key, value in fields.items():
+        if value is None:
+            continue
+        if isinstance(value, dict):
+            value = {k: ("<redacted>" if k in _AUDIT_REDACT else v) for k, v in value.items()}
+        event[key] = value
+    print(json.dumps(event, default=str), file=sys.stderr, flush=True)
+
+
 def _guard_write(*, account: Optional[str] = None, **context) -> Optional[str]:
     """Block writes in read-only mode, preview them in dry-run mode.
 
     Evaluates the resolved account's safety flags. Returns a JSON string to
     short-circuit the caller, or None to proceed. `account` is keyword-only so it
-    never leaks into the dry-run preview built from **context.
+    never leaks into the dry-run preview built from **context. The dry-run preview and
+    audit events also surface the caller's risk tier so a gateway sees the destructive signal.
     """
+    caller = _caller_tool()
     resolved = _resolve_account(account)
     if "error" in resolved:
         return json.dumps({"error": resolved["error"]}, indent=2)
     if resolved["read_only"]:
+        _emit_audit(caller, "blocked_read_only", account=resolved["name"], args=dict(context))
         return json.dumps({"error": "Server is in read-only mode. Set MAILCHIMP_READ_ONLY=false to allow writes."}, indent=2)
     if resolved["dry_run"]:
-        return json.dumps({"dry_run": True, **context}, indent=2)
+        risk = TOOL_RISK.get(caller)
+        _emit_audit(caller, "dry_run", account=resolved["name"], args=dict(context))
+        return json.dumps({"dry_run": True, "risk": risk, "destructive": risk == "destructive", **context}, indent=2)
     return None
 
 
@@ -128,6 +190,15 @@ def mc_request(endpoint: str, params: Optional[dict] = None, body: Optional[dict
     api_key = resolved["api_key"]
     if not api_key:
         return {"error": "MAILCHIMP_API_KEY environment variable is not set. Get your API key at https://mailchimp.com/help/about-api-keys/"}
+    # Argument-contract validation: an empty interpolated path id yields a '//' segment, and
+    # count must respect the Mailchimp cap. Reject before dispatching so the gateway and the
+    # model get a clear, consistent error rather than an opaque 4xx.
+    if "//" in endpoint.lstrip("/"):
+        return {"error": "Missing a required path parameter (empty id in endpoint).", "endpoint": endpoint}
+    if params and isinstance(params.get("count"), int) and not (1 <= params["count"] <= 1000):
+        return {"error": "count must be between 1 and 1000.", "count": params["count"]}
+    if AUDIT_LOG:
+        _emit_audit(_caller_tool(), "executed", account=resolved["name"], method=method, endpoint=endpoint, args=params or body)
     url = f"{resolved['base_url']}/{endpoint.lstrip('/')}"
     auth = ("anystring", api_key)
     try:
@@ -7194,6 +7265,88 @@ def list_account_orders(count: int = 10, offset: int = 0, account: str | None = 
     if isinstance(data, dict) and "error" in data:
         return json.dumps(data, indent=2)
     return json.dumps(data, indent=2)
+
+
+# --- Runtime security guardrails ---
+# Irreversible real sends. Combined with the delete_* prefix, these define the 'destructive'
+# risk tier: irreversible data loss or an irreversible outbound send with wide blast radius.
+_DESTRUCTIVE_SEND = frozenset({"send_campaign", "resend_to_non_openers"})
+
+
+def _classify_risk(name: str, fn) -> str:
+    """Classify a tool as 'read', 'write', or 'destructive'.
+
+    Destructive = irreversible data loss (any delete_* tool, including the GDPR permanent
+    erase) or an irreversible real send. Write = any other tool that routes through the
+    _guard_write chokepoint (detected structurally via the function's referenced globals).
+    Read = everything else. The write/read split is derived, not hand-maintained, so it
+    cannot drift; only the destructive set needs human judgement.
+    """
+    if name.startswith("delete_") or name in _DESTRUCTIVE_SEND:
+        return "destructive"
+    if "_guard_write" in fn.__code__.co_names:
+        return "write"
+    return "read"
+
+
+def _idempotent(name: str) -> bool:
+    """Deletes and PUT-based upserts are safe to repeat; other writes are not asserted idempotent."""
+    return name.startswith("delete_") or name.startswith("upsert_")
+
+
+@mcp.tool()
+def describe_tools() -> str:
+    """List every tool with its machine-readable risk classification for policy enforcement.
+
+    Use this to discover which tools are reads, reversible writes, or destructive (irreversible)
+    before granting access or building automation. A runtime-security gateway can also read the
+    same signal from the MCP tool annotations (readOnlyHint / destructiveHint / idempotentHint)
+    exposed via tools/list; this tool is the convenience, tool-call-based view of that metadata.
+
+    No network call. Read-only, safe to retry.
+
+    Returns:
+        JSON with summary (counts per risk tier and destructive total) and tools array. Each:
+        name, risk ('read' | 'write' | 'destructive'), read_only (bool), destructive (bool),
+        idempotent (bool).
+    """
+    tools = []
+    for name in sorted(TOOL_RISK):
+        risk = TOOL_RISK[name]
+        tools.append({
+            "name": name,
+            "risk": risk,
+            "read_only": risk == "read",
+            "destructive": risk == "destructive",
+            "idempotent": _idempotent(name),
+        })
+    summary = {
+        "total": len(tools),
+        "read": sum(1 for t in tools if t["risk"] == "read"),
+        "write": sum(1 for t in tools if t["risk"] == "write"),
+        "destructive": sum(1 for t in tools if t["risk"] == "destructive"),
+    }
+    return json.dumps({"summary": summary, "tools": tools}, indent=2)
+
+
+def _apply_tool_annotations() -> None:
+    """Populate TOOL_RISK and attach MCP-standard risk annotations to every registered tool.
+
+    Runs once at import, after all tools are registered. Reads the FastMCP tool registry so the
+    risk metadata (readOnlyHint / destructiveHint / idempotentHint) travels through the MCP
+    protocol's tools/list, letting a gateway enforce policy on the destructive signal directly.
+    """
+    for tool in mcp._tool_manager.list_tools():
+        risk = _classify_risk(tool.name, tool.fn)
+        TOOL_RISK[tool.name] = risk
+        tool.annotations = ToolAnnotations(
+            readOnlyHint=risk == "read",
+            destructiveHint=risk == "destructive",
+            idempotentHint=_idempotent(tool.name),
+        )
+
+
+_apply_tool_annotations()
 
 
 def main():

--- a/tests/test_account_coverage.py
+++ b/tests/test_account_coverage.py
@@ -11,8 +11,8 @@ import inspect
 
 from mailchimp_mcp_server import server
 
-# list_accounts intentionally takes no `account` (it lists them).
-_EXEMPT = {"list_accounts"}
+# list_accounts and describe_tools are account-agnostic metadata tools with no network call.
+_EXEMPT = {"list_accounts", "describe_tools"}
 
 _TREE = ast.parse(inspect.getsource(server))
 _TOOLS = [

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1,0 +1,117 @@
+"""Tests for the runtime-security guardrails: risk metadata, MCP annotations,
+structured audit events, and argument-contract validation."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from mailchimp_mcp_server import server
+
+
+def _events(err: str) -> list[dict]:
+    return [json.loads(line) for line in err.splitlines() if line.strip().startswith("{")]
+
+
+class TestRiskMetadata:
+    def test_describe_tools_classifies_and_counts(self) -> None:
+        payload = json.loads(server.describe_tools())
+        summary = payload["summary"]
+        assert summary["total"] == len(server.TOOL_RISK)
+        assert summary["read"] + summary["write"] + summary["destructive"] == summary["total"]
+        # every delete_* tool is destructive
+        assert summary["destructive"] >= sum(1 for n in server.TOOL_RISK if n.startswith("delete_"))
+
+        by_name = {t["name"]: t for t in payload["tools"]}
+        assert by_name["delete_campaign"]["risk"] == "destructive"
+        assert by_name["delete_campaign"]["destructive"] is True
+        assert by_name["delete_campaign"]["idempotent"] is True
+        assert by_name["send_campaign"]["risk"] == "destructive"
+        assert by_name["send_campaign"]["idempotent"] is False
+        assert by_name["list_campaigns"]["risk"] == "read"
+        assert by_name["list_campaigns"]["read_only"] is True
+        assert by_name["upsert_member"]["risk"] == "write"
+        assert by_name["upsert_member"]["idempotent"] is True
+
+    def test_mcp_annotations_expose_risk(self) -> None:
+        tm = server.mcp._tool_manager
+        assert tm.get_tool("delete_store").annotations.destructiveHint is True
+        assert tm.get_tool("delete_store").annotations.idempotentHint is True
+        assert tm.get_tool("list_audiences").annotations.readOnlyHint is True
+        assert tm.get_tool("list_audiences").annotations.destructiveHint is False
+        assert tm.get_tool("create_campaign").annotations.readOnlyHint is False
+        assert tm.get_tool("create_campaign").annotations.destructiveHint is False
+
+
+class TestArgumentValidation:
+    def test_rejects_out_of_range_count(self) -> None:
+        out = server.mc_request("/lists", params={"count": 5000})
+        assert "error" in out and "1 and 1000" in out["error"]
+
+    def test_rejects_empty_path_parameter(self) -> None:
+        out = server.mc_request("/lists//members")
+        assert "error" in out and "required path parameter" in out["error"]
+
+    def test_allows_account_root(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"account_name": "Acme"}
+        with patch.object(requests, "request", return_value=mock_resp):
+            out = server.mc_request("/")
+        assert out == {"account_name": "Acme"}
+
+
+class TestAuditLog:
+    def test_off_by_default_is_silent(self, capsys) -> None:
+        # AUDIT_LOG defaults off; a blocked write must not emit anything.
+        server._emit_audit("delete_campaign", "blocked_read_only", account="default")
+        assert capsys.readouterr().err == ""
+
+    def test_blocked_write_is_audited(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(server, "AUDIT_LOG", True)
+        monkeypatch.setattr(server, "READ_ONLY", True)
+        server.delete_campaign(campaign_id="c1")
+        events = _events(capsys.readouterr().err)
+        match = [e for e in events if e["tool"] == "delete_campaign"]
+        assert match and match[0]["outcome"] == "blocked_read_only"
+        assert match[0]["risk"] == "destructive"
+        assert match[0]["destructive"] is True
+
+    def test_dry_run_preview_and_event_carry_risk(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(server, "AUDIT_LOG", True)
+        monkeypatch.setattr(server, "DRY_RUN", True)
+        payload = json.loads(server.delete_store(store_id="s1"))
+        assert payload["dry_run"] is True
+        assert payload["risk"] == "destructive"
+        assert payload["destructive"] is True
+        events = _events(capsys.readouterr().err)
+        assert any(e["tool"] == "delete_store" and e["outcome"] == "dry_run" for e in events)
+
+    def test_executed_read_is_audited(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(server, "AUDIT_LOG", True)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"lists": [], "total_items": 0}
+        with patch.object(requests, "request", return_value=mock_resp):
+            server.list_audiences()
+        events = _events(capsys.readouterr().err)
+        match = [e for e in events if e["tool"] == "list_audiences"]
+        assert match and match[0]["outcome"] == "executed"
+        assert match[0]["risk"] == "read"
+        assert match[0]["method"] == "GET"
+
+    def test_audit_redacts_file_data(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(server, "AUDIT_LOG", True)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"id": 1}
+        with patch.object(requests, "request", return_value=mock_resp):
+            server.upload_file(name="a.png", file_data="SUPERSECRETBASE64")
+        err = capsys.readouterr().err
+        assert "SUPERSECRETBASE64" not in err
+        assert "<redacted>" in err


### PR DESCRIPTION
## What
Implements the server-side runtime-security guardrails discussed in #36. The design follows the defense-in-depth split from that thread: **the server owns the semantics** (which tools are reads, reversible writes, or irreversible) and exposes them as machine-readable signals, so an external gateway can enforce policy on the `destructive` signal instead of guessing which calls are dangerous.

## Risk metadata
Every tool is classified `read` / `write` / `destructive`. Destructive = irreversible data loss (any `delete_*`, incl. GDPR `delete_member_permanent`) or an irreversible send (`send_campaign`, `resend_to_non_openers`). Current split: **227 tools → 115 read, 81 write, 31 destructive**. The write/read split is *derived* from the `_guard_write` chokepoint (via `co_names`), so it can't drift; only the destructive rule is explicit.

Surfaced two ways:
- **MCP tool annotations** — `readOnlyHint` / `destructiveHint` / `idempotentHint`, attached at import and delivered through the standard `tools/list`. Zero per-tool edits.
- **`describe_tools`** — a read tool returning `{name, risk, read_only, destructive, idempotent}` per tool + per-tier counts.

## Structured audit log
`MAILCHIMP_AUDIT_LOG=true` emits one JSON event per dispatch to stderr from the two chokepoints (`mc_request`, `_guard_write`): tool, risk tier, `destructive` flag, account, outcome (`executed` / `blocked_read_only` / `dry_run`), and inspected args. Bulky/sensitive values (e.g. base64 `file_data`) are redacted; response bodies are never logged (response scanning stays a gateway concern). Off by default, zero overhead when disabled.

## Argument-contract validation
`mc_request` rejects out-of-range `count` (must be 1–1000) and missing path IDs (empty interpolated segment) before dispatch. The dry-run preview now also carries the tool's `risk` / `destructive`.

## Design notes
- No new dependency; uses `mcp.types.ToolAnnotations` and the FastMCP tool registry.
- Chokepoints identify the calling tool via frame introspection, so audit/risk require **no per-tool changes** across all 227 tools.
- `describe_tools` is exempt from the `account` coverage test (account-agnostic metadata tool, like `list_accounts`).

## Tests
10 new tests (classification, MCP annotations, audit blocked/dry-run/executed/redaction, count + path validation). Full suite: **133 passed**, `ruff` clean.