### PR TITLE
docs: refresh marketing copy (227 tools, e-commerce writes, guardrails)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![MCP](https://img.shields.io/badge/MCP-compatible-green.svg)](https://modelcontextprotocol.io)
 
-The most complete [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/) — **227 tools** to query and manage your Mailchimp account from any MCP-compatible client, with A/B campaign support, geographic reporting, full landing-page lifecycle, CRM-style member notes, e-commerce carts and promo codes, Classic Automation + Customer Journey reporting, and read-only / dry-run safety modes.
+The most complete [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/): **227 tools** to query and manage your Mailchimp account from any MCP-compatible client. It covers the full campaign, audience, member, segment, automation and reporting surface, complete e-commerce (read and write), landing pages, File Manager, surveys, signup forms and verified domains, plus multi-account support and runtime-security guardrails (read-only, dry-run and audit modes, with per-tool risk metadata).
 
 Uses the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/api/) via [`requests`](https://pypi.org/project/requests/). Not based on the official [mailchimp-marketing-python](https://github.com/mailchimp/mailchimp-marketing-python) client. I hit too many issues with it so I went with raw HTTP calls instead.
 

--- a/glama.json
+++ b/glama.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "mailchimp-mcp",
-  "description": "MCP server for the Mailchimp Marketing API. 227 tools for managing campaigns, audiences, members, templates, segments, Classic Automations and Customer Journey workarounds, reports, e-commerce (carts, promo rules and codes), A/B testing, landing pages, CRM notes, multi-account support, File Manager, surveys, signup forms, verified domains, deliverability, full e-commerce writes, and more.",
+  "description": "MCP server for the Mailchimp Marketing API. 227 tools for managing campaigns, audiences, members, templates, segments, Classic Automations and Customer Journey workarounds, reports, e-commerce (carts, promo rules and codes), A/B testing, landing pages, CRM notes, multi-account support, File Manager, surveys, signup forms, verified domains, deliverability, full e-commerce writes, and runtime-security guardrails (per-tool risk metadata, structured audit log, argument validation), and more.",
   "author": {
     "name": "Damien Tilman",
     "url": "https://github.com/damientilman"


### PR DESCRIPTION
The README headline and `glama.json` description trailed the actual scope.

- README headline: kept the accurate **227 tools** count but rewrote the feature clause, which still advertised only "e-commerce carts and promo codes" and "read-only / dry-run safety modes". It now reflects complete e-commerce (read + write), File Manager, surveys, signup forms, verified domains, multi-account support, and the runtime-security guardrails.
- `glama.json`: added the runtime-security guardrails to the description.

The GitHub repo "About" description was separately corrected (it still said 112 tools).

Docs only; no code change.