### PR TITLE
release: v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-07-01
+
 ### Added
 - **Runtime security guardrails** (#36) — server-side signals a runtime-security gateway can
   enforce on, following the defense-in-depth split discussed in the community thread:
@@ -65,6 +67,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Account selectors are now matched case-insensitively — a capitalized `account`
   (e.g. `"Marketing"`, `"Default"`) resolves to the configured account instead of erroring,
   matching how account names are lowercased when the registry is built.
+- The `ToolAnnotations` import is now optional — on older `mcp` SDKs that predate tool
+  annotations the server still imports and runs; risk metadata remains available via
+  `describe_tools`, only the `tools/list` annotations are skipped.
 
 ## [0.7.0] - 2026-06-24
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mailchimp-mcp"
-version = "0.7.0"
+version = "1.0.0"
 description = "MCP server for the Mailchimp Marketing API — access campaigns, audiences, reports, and more from any MCP-compatible client."
 readme = "README.md"
 license = "MIT"

--- a/src/mailchimp_mcp_server/server.py
+++ b/src/mailchimp_mcp_server/server.py
@@ -7,7 +7,11 @@ from typing import Optional
 
 import requests
 from mcp.server.fastmcp import FastMCP
-from mcp.types import ToolAnnotations
+
+try:
+    from mcp.types import ToolAnnotations
+except ImportError:  # older mcp SDK without tool annotations; risk metadata still ships via describe_tools
+    ToolAnnotations = None
 
 # --- Config ---
 # The plain MAILCHIMP_API_KEY is the implicit "default" account. It is served from
@@ -7339,11 +7343,12 @@ def _apply_tool_annotations() -> None:
     for tool in mcp._tool_manager.list_tools():
         risk = _classify_risk(tool.name, tool.fn)
         TOOL_RISK[tool.name] = risk
-        tool.annotations = ToolAnnotations(
-            readOnlyHint=risk == "read",
-            destructiveHint=risk == "destructive",
-            idempotentHint=_idempotent(tool.name),
-        )
+        if ToolAnnotations is not None:
+            tool.annotations = ToolAnnotations(
+                readOnlyHint=risk == "read",
+                destructiveHint=risk == "destructive",
+                idempotentHint=_idempotent(tool.name),
+            )
 
 
 _apply_tool_annotations()


### PR DESCRIPTION
Cuts **v1.0.0**. Everything under `[Unreleased]` becomes `[1.0.0] - 2026-07-01`.

Highlights since 0.7.0 (all backward-compatible; single-key setups unchanged):
- Multi-account support (`account` per call, per-account safety flags)
- Coverage expansion 115 → 227 tools: File Manager, Surveys, Signup forms, Verified Domains, reporting depth, deliverability, automation controls, and full e-commerce writes
- Runtime-security guardrails: per-tool risk metadata (MCP annotations + `describe_tools`), structured audit log, argument-contract validation

Release hygiene in this PR:
- `pyproject` version 0.7.0 → 1.0.0
- CHANGELOG dated
- `ToolAnnotations` import made optional (graceful degradation on older `mcp` SDKs)

`uv build` produces `mailchimp_mcp-1.0.0` sdist + wheel. Tagging `v1.0.0` after merge triggers the PyPI publish workflow.