### PR TITLE
chore: gitignore local working notes (tasks/) and .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ htmlcov/
 .ruff_cache/
 .mypy_cache/
 uv.lock
+
+# Local working notes (plans, growth drafts) - never publish
+tasks/
+.DS_Store


### PR DESCRIPTION
Prevents local plans and growth drafts under `tasks/` (and macOS `.DS_Store`) from ever being staged into the public repo by accident. No code change.