### PR TITLE
feat: tool profiles + leaner descriptions (shrink tools/list token footprint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Tool profiles** — `MAILCHIMP_TOOLS` selects which tools to expose, to shrink the tool-list
+  payload sent to the model on every turn. Accepts a comma-separated mix of risk tiers
+  (`read` / `write` / `destructive`) and/or exact tool names; unset or `all` exposes everything.
+  Example: `MAILCHIMP_TOOLS=read` loads ~115 read tools (~29k tokens) instead of all 227 (~63k).
+
+### Changed
+- **Leaner tool descriptions** — repeated per-tool boilerplate (the "Authenticated via API key…"
+  note and the identical `account:` argument line) is trimmed from the wire descriptions at
+  import, cutting the full tool-list footprint by roughly 18% with no loss of tool-selection
+  information. Source docstrings are unchanged.
+
 ## [1.0.0] - 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ pip install -e .
 | `MAILCHIMP_READ_ONLY_<NAME>` | No | Read-only mode for a specific named account (default: `false`) |
 | `MAILCHIMP_DRY_RUN_<NAME>` | No | Dry-run mode for a specific named account (default: `false`) |
 | `MAILCHIMP_AUDIT_LOG` | No | Set to `true` to emit a structured JSON audit event per tool dispatch to stderr (default: `false`). See [Runtime security](#runtime-security). |
+| `MAILCHIMP_TOOLS` | No | Expose only a subset of tools to shrink the model's tool-list footprint (default: all). See [Tool profiles](#tool-profiles). |
 
 The datacenter (`us8`, `us21`, etc.) is automatically extracted from each key.
 
@@ -155,6 +156,22 @@ The server is designed for defense-in-depth alongside an external MCP gateway: i
 **Structured audit log** — With `MAILCHIMP_AUDIT_LOG=true`, each dispatch emits one JSON event to stderr with the tool, its risk tier, the `destructive` flag, the target account, the outcome (`executed` / `blocked_read_only` / `dry_run`), and the inspected arguments. Bulky or sensitive values (e.g. base64 `file_data`) are redacted and response bodies are never logged, so the stream is a safe audit sink to tail centrally.
 
 **Argument-contract validation** — All writes funnel through a single `_guard_write` chokepoint, and every request is validated before dispatch (pagination `count` capped to 1–1000, missing path IDs rejected), so malformed calls fail fast and consistently instead of hitting the API.
+
+### Tool profiles
+
+Exposing all 227 tools sends a large tool list to the model on every turn (~63k tokens). If you only need part of the surface, load a subset with one line:
+
+```json
+"env": { "MAILCHIMP_API_KEY": "your-key-us8", "MAILCHIMP_TOOLS": "read" }
+```
+
+`MAILCHIMP_TOOLS` accepts a comma-separated mix of **risk tiers** (`read`, `write`, `destructive`) and/or **exact tool names**; a tool is kept if either matches. Unset (or `all`) exposes everything.
+
+- `read` — reporting and analytics only (~115 tools, ~29k tokens). A safe, lightweight default for exploration.
+- `read,write` — everything except irreversible tools.
+- `list_campaigns,get_campaign_report,send_campaign` — a hand-picked minimal set.
+
+Tool descriptions are also trimmed of repeated boilerplate before they reach the model, so even the full set is leaner than the raw docstrings. Use `describe_tools` to see each tool's risk tier.
 
 ### Multi-account
 

--- a/src/mailchimp_mcp_server/server.py
+++ b/src/mailchimp_mcp_server/server.py
@@ -25,6 +25,10 @@ DRY_RUN = os.environ.get("MAILCHIMP_DRY_RUN", "").lower() in ("1", "true", "yes"
 # When MAILCHIMP_AUDIT_LOG is truthy, every tool dispatch emits a structured JSON audit
 # event to stderr (see _emit_audit). Off by default; zero overhead when disabled.
 AUDIT_LOG = os.environ.get("MAILCHIMP_AUDIT_LOG", "").lower() in ("1", "true", "yes")
+# MAILCHIMP_TOOLS selects which tools to expose, to shrink the tools/list payload the client
+# sends to the model. Empty or "all" exposes everything; otherwise a comma-separated mix of risk
+# tiers (read / write / destructive) and/or exact tool names. See _selected_tool_names.
+TOOLS_PROFILE = os.environ.get("MAILCHIMP_TOOLS", "").strip()
 
 DEFAULT_ACCOUNT = "default"
 
@@ -7351,7 +7355,69 @@ def _apply_tool_annotations() -> None:
             )
 
 
+def _slim_description(text: str) -> str:
+    """Drop the two per-tool boilerplate lines from the wire description.
+
+    Every docstring repeats the "Authenticated via API key. Max 10 concurrent requests..."
+    note and an identical `account:` argument line. They add nothing to tool selection and,
+    multiplied across 200+ tools, cost thousands of tokens in every tools/list. Only the
+    runtime Tool.description is trimmed; the source docstrings stay full for developers.
+    """
+    lines = [
+        line for line in text.split("\n")
+        if not line.strip().startswith("Authenticated via API key.")
+        and not (line.strip().startswith("account:") and "MAILCHIMP_API_KEY_<NAME>" in line)
+    ]
+    # Drop an "Args:" header left empty once `account` was its only entry.
+    cleaned = []
+    for i, line in enumerate(lines):
+        if line.strip() == "Args:":
+            following = next((n.strip() for n in lines[i + 1:] if n.strip()), "")
+            if not following or following.startswith("Returns:"):
+                continue
+        cleaned.append(line)
+    out = "\n".join(cleaned)
+    while "\n\n\n" in out:
+        out = out.replace("\n\n\n", "\n\n")
+    return out.strip()
+
+
+def _optimize_descriptions() -> None:
+    """Shrink the tools/list payload by trimming boilerplate from every tool's wire description."""
+    for tool in mcp._tool_manager.list_tools():
+        if tool.description:
+            tool.description = _slim_description(tool.description)
+
+
+def _selected_tool_names(spec: str, risk_map: dict) -> Optional[set]:
+    """Resolve the MAILCHIMP_TOOLS spec to the set of tool names to keep, or None for all.
+
+    spec is a comma-separated mix of risk tiers ('read' / 'write' / 'destructive') and/or exact
+    tool names. A tool is kept if its name is listed or its risk tier is listed. Empty or 'all'
+    returns None (keep everything).
+    """
+    spec = (spec or "").strip().lower()
+    if not spec or spec == "all":
+        return None
+    wanted = {part.strip() for part in spec.split(",") if part.strip()}
+    tiers = wanted & {"read", "write", "destructive"}
+    return {name for name, risk in risk_map.items() if name in wanted or risk in tiers}
+
+
+def _apply_tool_profile() -> None:
+    """Remove tools outside the selected MAILCHIMP_TOOLS profile from the registry."""
+    keep = _selected_tool_names(TOOLS_PROFILE, TOOL_RISK)
+    if keep is None:
+        return
+    for name in list(TOOL_RISK):
+        if name not in keep:
+            mcp._tool_manager.remove_tool(name)
+            del TOOL_RISK[name]
+
+
 _apply_tool_annotations()
+_optimize_descriptions()
+_apply_tool_profile()
 
 
 def main():

--- a/tests/test_tool_profiles.py
+++ b/tests/test_tool_profiles.py
@@ -1,0 +1,64 @@
+"""Tests for the tools/list footprint optimizations: description trimming and tool profiles."""
+
+from __future__ import annotations
+
+import inspect
+
+from mailchimp_mcp_server import server
+
+
+class TestDescriptionTrim:
+    def test_boilerplate_removed_from_wire_descriptions(self) -> None:
+        for tool in server.mcp._tool_manager.list_tools():
+            description = tool.description or ""
+            assert "Authenticated via API key." not in description
+            assert "account: Optional account name" not in description
+
+    def test_source_docstrings_stay_full(self) -> None:
+        # Trimming is runtime-only; the source docstrings keep the account line the
+        # coverage test relies on.
+        source = inspect.getsource(server.get_audience_details)
+        assert "account: Optional account name" in source
+
+    def test_summary_and_args_preserved(self) -> None:
+        description = server.mcp._tool_manager.get_tool("list_files").description
+        assert description.startswith("List images and files")
+        assert "count:" in description  # real argument docs kept
+        assert "offset:" in description
+
+    def test_empty_args_header_dropped(self) -> None:
+        # get_account_info's only parameter was `account`; the now-empty Args: header is gone.
+        description = server.mcp._tool_manager.get_tool("get_account_info").description
+        assert "Args:" not in description
+        assert description.startswith("Retrieve Mailchimp account details")
+
+
+class TestSelectedToolNames:
+    RISK = {"list_x": "read", "create_x": "write", "delete_x": "destructive"}
+
+    def test_empty_or_all_keeps_everything(self) -> None:
+        assert server._selected_tool_names("", self.RISK) is None
+        assert server._selected_tool_names("all", self.RISK) is None
+        assert server._selected_tool_names("  ", self.RISK) is None
+
+    def test_single_tier(self) -> None:
+        assert server._selected_tool_names("read", self.RISK) == {"list_x"}
+
+    def test_multiple_tiers(self) -> None:
+        assert server._selected_tool_names("read,write", self.RISK) == {"list_x", "create_x"}
+
+    def test_explicit_tool_name(self) -> None:
+        assert server._selected_tool_names("delete_x", self.RISK) == {"delete_x"}
+
+    def test_mixed_names_and_tiers(self) -> None:
+        assert server._selected_tool_names("read,delete_x", self.RISK) == {"list_x", "delete_x"}
+
+    def test_case_insensitive(self) -> None:
+        assert server._selected_tool_names("READ", self.RISK) == {"list_x"}
+
+
+class TestDefaultProfile:
+    def test_default_process_exposes_all_tools(self) -> None:
+        # With MAILCHIMP_TOOLS unset (the test env), nothing is filtered out.
+        assert len(server.mcp._tool_manager.list_tools()) == len(server.TOOL_RISK)
+        assert len(server.TOOL_RISK) > 200


### PR DESCRIPTION
Addresses the real cost of a 227-tool server: the tool list sent to the model on every turn. Measured footprint was ~77k tokens; this brings the default down to ~63k and lets users opt into far smaller subsets.

## Tool profiles — `MAILCHIMP_TOOLS`
One env line selects which tools to expose:
```json
"env": { "MAILCHIMP_API_KEY": "…", "MAILCHIMP_TOOLS": "read" }
```
Accepts a comma-separated mix of **risk tiers** (`read` / `write` / `destructive`) and/or **exact tool names**; a tool is kept if either matches. Unset or `all` exposes everything.
- `read` → ~115 tools, ~29k tokens (safe, lightweight default for exploration)
- `read,write` → everything except irreversible tools
- explicit names → a hand-picked minimal set

Filtering runs at import against the FastMCP registry (`remove_tool`), and composes with the existing risk tiers from the guardrails work.

## Leaner descriptions
The repeated per-tool boilerplate (`Authenticated via API key…` and the identical `account:` argument line) is trimmed from the **wire** descriptions at import — roughly 18% off the full payload with no loss of selection info. Source docstrings are untouched, so the `account` coverage test and developer-facing docs stay intact.

## Numbers
| Config | Tools | ~Tokens |
|---|---|---|
| before | 227 | ~77k |
| default (trimmed) | 227 | ~63k |
| `MAILCHIMP_TOOLS=read` | 115 | ~29k |

## Tests
11 new tests (`_selected_tool_names` pure-function matrix, trim assertions, default-exposes-all). Full suite **144 passed**, ruff clean.