### PR TITLE
fix: reliability hardening and correctness gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `delete_member` and `tag_member` now surface the API error instead of always reporting
+  success — a failed GDPR deletion no longer returns a false `permanently_deleted` confirmation.
+- Malformed JSON passed to `batch_subscribe`, `create_segment`, `update_segment`, or
+  `create_batch` returns a readable error instead of raising an unhandled exception.
+- Path parameters containing `..` are rejected before dispatch, closing an endpoint-traversal
+  gap the empty-segment (`//`) check missed.
+- Audit log now redacts subscriber PII (`email_address`, `email`, `merge_fields`) at any depth,
+  including inside `batch_subscribe` member arrays; previously only `file_data` was masked.
+- Corrected the contradictory docs on `delete_member` / `delete_member_permanent`: both call the
+  same permanent-deletion endpoint and are equivalent.
+
 ### Added
 - **Tool profiles** — `MAILCHIMP_TOOLS` selects which tools to expose, to shrink the tool-list
   payload sent to the model on every turn. Accepts a comma-separated mix of risk tiers
   (`read` / `write` / `destructive`) and/or exact tool names; unset or `all` exposes everything.
   Example: `MAILCHIMP_TOOLS=read` loads ~115 read tools (~29k tokens) instead of all 227 (~63k).
+- **Automatic retries** on transient failures (429 and 5xx) with exponential backoff, honoring
+  the `Retry-After` header. Configurable via `MAILCHIMP_MAX_RETRIES` (default 3). Network
+  timeouts are not retried, so a write that may already have landed is never replayed.
+- **Connection pooling** — one keep-alive `requests.Session` per account, so sequential calls
+  reuse the TCP/TLS connection instead of reconnecting each time.
 
 ### Changed
 - **Leaner tool descriptions** — repeated per-tool boilerplate (the "Authenticated via API key…"
   note and the identical `account:` argument line) is trimmed from the wire descriptions at
   import, cutting the full tool-list footprint by roughly 18% with no loss of tool-selection
   information. Source docstrings are unchanged.
+- Email addresses are validated before use; a malformed address returns a clear error instead
+  of a confusing 404 against a hash that matches no member.
+- `batch_subscribe` enforces the documented 500-member cap, and `offset` must be zero or greater.
 
 ## [1.0.0] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Every write and destructive tool now surfaces the API error instead of reporting a hard-coded
+  success. Around 20 tools — including `send_campaign`, `send_test_email`, `schedule_campaign`,
+  `cancel_send`, `delete_campaign`, `pause_automation`, and the `delete_*` family — previously
+  discarded the API result and always returned success, so a rejected send was reported as
+  `sent` and a failed delete as `deleted`. The error each docstring promised is now actually
+  returned.
 - `delete_member` and `tag_member` now surface the API error instead of always reporting
   success — a failed GDPR deletion no longer returns a false `permanently_deleted` confirmation.
+- `tag_member` no longer documents "read scope required": it is a write, and the note is dropped
+  to match the other tools.
+- The `idempotent` hint (MCP annotation and `describe_tools`) now agrees with the docstrings for
+  `update_member`, `tag_member`, `update_segment`, and `publish_landing_page`, which state they
+  are idempotent but were previously reported otherwise.
 - Malformed JSON passed to `batch_subscribe`, `create_segment`, `update_segment`, or
   `create_batch` returns a readable error instead of raising an unhandled exception.
 - Path parameters containing `..` are rejected before dispatch, closing an endpoint-traversal

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,6 +1,5 @@
 # Smithery configuration for one-click install (https://smithery.ai/docs).
-# Local stdio server run via uvx. Verify field names against the current Smithery
-# docs before publishing; a hosted deployment would additionally need a Dockerfile.
+# Local stdio server run via uvx.
 startCommand:
   type: stdio
   configSchema:

--- a/src/mailchimp_mcp_server/server.py
+++ b/src/mailchimp_mcp_server/server.py
@@ -1,7 +1,9 @@
 import hashlib
 import json
 import os
+import re
 import sys
+import time
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -30,6 +32,18 @@ AUDIT_LOG = os.environ.get("MAILCHIMP_AUDIT_LOG", "").lower() in ("1", "true", "
 # tiers (read / write / destructive) and/or exact tool names. See _selected_tool_names.
 TOOLS_PROFILE = os.environ.get("MAILCHIMP_TOOLS", "").strip()
 
+# Transient HTTP failures are retried with exponential backoff. Mailchimp caps concurrency at
+# 10 and returns 429 (with a Retry-After header) when throttled; 5xx are typically upstream
+# blips. The count is configurable via MAILCHIMP_MAX_RETRIES (default 3, i.e. up to 4 attempts).
+# Network exceptions (timeout / connection reset) are NOT retried: a write may already have
+# landed server-side, so replaying it could duplicate the effect.
+try:
+    MAX_RETRIES = max(0, int(os.environ.get("MAILCHIMP_MAX_RETRIES", "3")))
+except ValueError:
+    MAX_RETRIES = 3
+_RETRY_STATUSES = frozenset({429, 500, 502, 503, 504})
+_BACKOFF_BASE = 1.0  # seconds; attempt N waits _BACKOFF_BASE * 2**N -> 1s, 2s, 4s
+
 DEFAULT_ACCOUNT = "default"
 
 # Machine-readable risk tier per tool name ('read' | 'write' | 'destructive'), populated at
@@ -39,8 +53,10 @@ DEFAULT_ACCOUNT = "default"
 # policy on the destructive signal via tools/list instead of guessing which calls are dangerous.
 TOOL_RISK: dict = {}
 
-# Params whose values are bulky or sensitive and must not appear verbatim in audit events.
-_AUDIT_REDACT = frozenset({"file_data"})
+# Params whose values are bulky or sensitive (PII) and must not appear verbatim in audit
+# events: subscriber emails and merge fields (name, address, phone) fall under GDPR, and
+# file_data is bulky base64. Redacted to '<redacted>' by _emit_audit before the event is written.
+_AUDIT_REDACT = frozenset({"file_data", "email_address", "email", "merge_fields"})
 
 
 def _truthy(value: str) -> bool:
@@ -145,9 +161,10 @@ def _emit_audit(tool_name: Optional[str], outcome: str, **fields) -> None:
     """Emit one structured JSON audit event to stderr (no-op unless MAILCHIMP_AUDIT_LOG is on).
 
     Events carry the tool, its risk tier, the outcome ('executed' / 'blocked_read_only' /
-    'dry_run' / 'error'), the target account, and the inspected call arguments. Bulky or
-    sensitive param values (see _AUDIT_REDACT) are redacted; response bodies are never logged.
-    A gateway can tail this stream as a tamper-evident audit sink.
+    'dry_run' / 'error'), the target account, and the inspected call arguments. Sensitive PII
+    and bulky param values (see _AUDIT_REDACT) are redacted at any depth, including inside
+    nested member lists (e.g. batch_subscribe); response bodies are never logged. A gateway can
+    tail this stream as a tamper-evident audit sink.
     """
     if not AUDIT_LOG:
         return
@@ -162,10 +179,18 @@ def _emit_audit(tool_name: Optional[str], outcome: str, **fields) -> None:
     for key, value in fields.items():
         if value is None:
             continue
-        if isinstance(value, dict):
-            value = {k: ("<redacted>" if k in _AUDIT_REDACT else v) for k, v in value.items()}
-        event[key] = value
+        event[key] = _redact_pii(value)
     print(json.dumps(event, default=str), file=sys.stderr, flush=True)
+
+
+def _redact_pii(value):
+    """Recursively replace any _AUDIT_REDACT key's value with '<redacted>', descending into
+    nested dicts and lists so PII buried in a member array is masked too."""
+    if isinstance(value, dict):
+        return {k: ("<redacted>" if k in _AUDIT_REDACT else _redact_pii(v)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_pii(item) for item in value]
+    return value
 
 
 def _guard_write(*, account: Optional[str] = None, **context) -> Optional[str]:
@@ -190,6 +215,43 @@ def _guard_write(*, account: Optional[str] = None, **context) -> Optional[str]:
     return None
 
 
+# One pooled requests.Session per account (keyed by account name) so sequential tool calls
+# reuse the TCP/TLS connection instead of paying a fresh handshake each time. Populated lazily.
+_SESSIONS: dict = {}
+
+
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def _subscriber_hash(email_address: str) -> Optional[str]:
+    """Mailchimp's subscriber hash: MD5 of the lowercased email. Returns None when the address
+    is not a plausible email, so callers can surface a clear error instead of a confusing 404
+    against a hash that points at no one."""
+    if not email_address or not _EMAIL_RE.match(email_address.strip()):
+        return None
+    return hashlib.md5(email_address.strip().lower().encode()).hexdigest()
+
+
+def _session_for(name: str) -> requests.Session:
+    session = _SESSIONS.get(name)
+    if session is None:
+        session = requests.Session()
+        _SESSIONS[name] = session
+    return session
+
+
+def _retry_delay(resp: "requests.Response", attempt: int) -> float:
+    """Seconds to wait before the next attempt: honor the server's Retry-After header when
+    present (429 throttling), otherwise fall back to exponential backoff (1s, 2s, 4s...)."""
+    retry_after = resp.headers.get("Retry-After")
+    if retry_after:
+        try:
+            return max(0.0, float(retry_after))
+        except (TypeError, ValueError):
+            pass
+    return _BACKOFF_BASE * (2 ** attempt)
+
+
 def mc_request(endpoint: str, params: Optional[dict] = None, body: Optional[dict] = None, method: str = "GET", *, account: Optional[str] = None) -> dict:
     """Make an authenticated request to the Mailchimp API for the resolved account."""
     resolved = _resolve_account(account)
@@ -201,20 +263,31 @@ def mc_request(endpoint: str, params: Optional[dict] = None, body: Optional[dict
     # Argument-contract validation: an empty interpolated path id yields a '//' segment, and
     # count must respect the Mailchimp cap. Reject before dispatching so the gateway and the
     # model get a clear, consistent error rather than an opaque 4xx.
-    if "//" in endpoint.lstrip("/"):
+    stripped = endpoint.lstrip("/")
+    if "//" in stripped:
         return {"error": "Missing a required path parameter (empty id in endpoint).", "endpoint": endpoint}
+    if ".." in stripped.split("/"):
+        return {"error": "Invalid path segment (a path parameter contains '..').", "endpoint": endpoint}
     if params and isinstance(params.get("count"), int) and not (1 <= params["count"] <= 1000):
         return {"error": "count must be between 1 and 1000.", "count": params["count"]}
+    if params and isinstance(params.get("offset"), int) and params["offset"] < 0:
+        return {"error": "offset must be zero or greater.", "offset": params["offset"]}
     if AUDIT_LOG:
         _emit_audit(_caller_tool(), "executed", account=resolved["name"], method=method, endpoint=endpoint, args=params or body)
     url = f"{resolved['base_url']}/{endpoint.lstrip('/')}"
     auth = ("anystring", api_key)
-    try:
-        resp = requests.request(method, url, auth=auth, params=params, json=body, timeout=30)
-    except requests.exceptions.Timeout:
-        return {"error": "Request timed out after 30 seconds", "endpoint": endpoint}
-    except requests.exceptions.ConnectionError:
-        return {"error": "Could not connect to Mailchimp API", "endpoint": endpoint}
+    session = _session_for(resolved["name"])
+    for attempt in range(MAX_RETRIES + 1):
+        try:
+            resp = session.request(method, url, auth=auth, params=params, json=body, timeout=30)
+        except requests.exceptions.Timeout:
+            return {"error": "Request timed out after 30 seconds", "endpoint": endpoint}
+        except requests.exceptions.ConnectionError:
+            return {"error": "Could not connect to Mailchimp API", "endpoint": endpoint}
+        if resp.status_code in _RETRY_STATUSES and attempt < MAX_RETRIES:
+            time.sleep(_retry_delay(resp, attempt))
+            continue
+        break
     if resp.status_code == 204:
         return {"status": "success"}
     if not resp.ok:
@@ -1094,7 +1167,9 @@ def update_member(list_id: str, email_address: str, status: Optional[str] = None
     """
     if (guard := _guard_write(action="update member", email_address=email_address, list_id=list_id, account=account)):
         return guard
-    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    subscriber_hash = _subscriber_hash(email_address)
+    if subscriber_hash is None:
+        return json.dumps({"error": f"Invalid email address: {email_address!r}"}, indent=2)
     body: dict = {}
     if status:
         body["status"] = status
@@ -1133,7 +1208,9 @@ def unsubscribe_member(list_id: str, email_address: str, account: str | None = N
     """
     if (guard := _guard_write(action="unsubscribe member", email_address=email_address, list_id=list_id, account=account)):
         return guard
-    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    subscriber_hash = _subscriber_hash(email_address)
+    if subscriber_hash is None:
+        return json.dumps({"error": f"Invalid email address: {email_address!r}"}, indent=2)
     data = mc_request(f"/lists/{list_id}/members/{subscriber_hash}", body={"status": "unsubscribed"}, method="PATCH", account=account)
     return json.dumps({
         "email_address": data.get("email_address"),
@@ -1146,8 +1223,9 @@ def delete_member(list_id: str, email_address: str, account: str | None = None) 
     """Permanently delete a member and all their data from an audience.
 
     Use only for complete data removal (e.g. GDPR right-to-erasure requests). All activity history,
-    merge field data, and tag associations are permanently lost. Use unsubscribe_member instead to
-    stop sending while preserving data for reporting. There is no undo.
+    merge field data, and tag associations are permanently lost. Equivalent to delete_member_permanent
+    (same endpoint). Use unsubscribe_member instead to stop sending while preserving data for
+    reporting. There is no undo.
 
     Authenticated via API key. Subject to Mailchimp API rate limits (max 10 concurrent requests). This operation is irreversible. Respects read-only and dry-run modes.
 
@@ -1165,8 +1243,12 @@ def delete_member(list_id: str, email_address: str, account: str | None = None) 
     """
     if (guard := _guard_write(action="permanently delete member", email_address=email_address, list_id=list_id, account=account)):
         return guard
-    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
-    mc_request(f"/lists/{list_id}/members/{subscriber_hash}/actions/delete-permanent", method="POST", account=account)
+    subscriber_hash = _subscriber_hash(email_address)
+    if subscriber_hash is None:
+        return json.dumps({"error": f"Invalid email address: {email_address!r}"}, indent=2)
+    data = mc_request(f"/lists/{list_id}/members/{subscriber_hash}/actions/delete-permanent", method="POST", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "permanently_deleted", "email_address": email_address}, indent=2)
 
 
@@ -1195,7 +1277,9 @@ def tag_member(list_id: str, email_address: str, tags_to_add: Optional[str] = No
     """
     if (guard := _guard_write(action="update member tags", email_address=email_address, list_id=list_id, account=account)):
         return guard
-    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    subscriber_hash = _subscriber_hash(email_address)
+    if subscriber_hash is None:
+        return json.dumps({"error": f"Invalid email address: {email_address!r}"}, indent=2)
     tags = []
     if tags_to_add:
         for t in tags_to_add.split(","):
@@ -1203,7 +1287,9 @@ def tag_member(list_id: str, email_address: str, tags_to_add: Optional[str] = No
     if tags_to_remove:
         for t in tags_to_remove.split(","):
             tags.append({"name": t.strip(), "status": "inactive"})
-    mc_request(f"/lists/{list_id}/members/{subscriber_hash}/tags", body={"tags": tags}, method="POST", account=account)
+    data = mc_request(f"/lists/{list_id}/members/{subscriber_hash}/tags", body={"tags": tags}, method="POST", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "updated", "email_address": email_address, "tags": tags}, indent=2)
 
 
@@ -1231,7 +1317,12 @@ def batch_subscribe(list_id: str, members_json: str, update_existing: bool = Tru
     """
     if (guard := _guard_write(action="batch subscribe members", list_id=list_id, account=account)):
         return guard
-    members = json.loads(members_json)
+    try:
+        members = json.loads(members_json)
+    except json.JSONDecodeError as e:
+        return json.dumps({"error": f"Invalid members_json: {e}"}, indent=2)
+    if isinstance(members, list) and len(members) > 500:
+        return json.dumps({"error": f"members_json holds {len(members)} members; the max is 500. Use create_batch for larger imports."}, indent=2)
     body = {"members": members, "update_existing": update_existing}
     data = mc_request(f"/lists/{list_id}", body=body, method="POST", account=account)
     return json.dumps({
@@ -1797,7 +1888,10 @@ def create_segment(list_id: str, name: str, static: bool = True, match: Optional
         return guard
     body: dict = {"name": name}
     if match and conditions_json:
-        conditions = json.loads(conditions_json)
+        try:
+            conditions = json.loads(conditions_json)
+        except json.JSONDecodeError as e:
+            return json.dumps({"error": f"Invalid conditions_json: {e}"}, indent=2)
         body["options"] = {"match": match, "conditions": conditions}
     elif static:
         body["static_segment"] = []
@@ -1933,7 +2027,10 @@ def update_segment(list_id: str, segment_id: str, name: Optional[str] = None, ma
     if name:
         body["name"] = name
     if match and conditions_json:
-        conditions = json.loads(conditions_json)
+        try:
+            conditions = json.loads(conditions_json)
+        except json.JSONDecodeError as e:
+            return json.dumps({"error": f"Invalid conditions_json: {e}"}, indent=2)
         body["options"] = {"match": match, "conditions": conditions}
     data = mc_request(f"/lists/{list_id}/segments/{segment_id}", body=body, method="PATCH", account=account)
     return json.dumps({
@@ -2799,7 +2896,9 @@ def get_member_activity(list_id: str, email_address: str, count: int = 20, accou
         JSON with email_address and activity array. Each: action ('open'/'click'/'bounce'),
         timestamp, campaign_id, title.
     """
-    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    subscriber_hash = _subscriber_hash(email_address)
+    if subscriber_hash is None:
+        return json.dumps({"error": f"Invalid email address: {email_address!r}"}, indent=2)
     data = mc_request(f"/lists/{list_id}/members/{subscriber_hash}/activity", params={"count": count}, account=account)
     activities = []
     for a in data.get("activity", []):
@@ -2834,7 +2933,9 @@ def get_member_tags(list_id: str, email_address: str, count: int = 50, account: 
     Example:
         get_member_tags(list_id="abc123", email_address="jane@co.com") -> {"email_address": "jane@co.com", "total_items": 3, "tags": [{"name": "VIP", "date_added": "2025-01-15T10:00:00Z", ...}]}
     """
-    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    subscriber_hash = _subscriber_hash(email_address)
+    if subscriber_hash is None:
+        return json.dumps({"error": f"Invalid email address: {email_address!r}"}, indent=2)
     data = mc_request(f"/lists/{list_id}/members/{subscriber_hash}/tags", params={"count": count}, account=account)
     tags = []
     for t in data.get("tags", []):
@@ -2869,7 +2970,9 @@ def get_member_events(list_id: str, email_address: str, count: int = 20, account
     Example:
         get_member_events(list_id="abc123", email_address="jane@co.com") -> {"email_address": "jane@co.com", "total_items": 5, "events": [{"name": "purchased", "occurred_at": "2025-06-01T10:00:00Z", "properties": {"product": "T-Shirt"}}]}
     """
-    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    subscriber_hash = _subscriber_hash(email_address)
+    if subscriber_hash is None:
+        return json.dumps({"error": f"Invalid email address: {email_address!r}"}, indent=2)
     data = mc_request(f"/lists/{list_id}/members/{subscriber_hash}/events", params={"count": count}, account=account)
     events = []
     for e in data.get("events", []):
@@ -2908,7 +3011,9 @@ def get_member_journey_events(list_id: str, email_address: str, count: int = 50,
         filtering), and events array. Each event: action (raw action type), timestamp, title
         (campaign / automation title if present), url (link clicked if any), campaign_id.
     """
-    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    subscriber_hash = _subscriber_hash(email_address)
+    if subscriber_hash is None:
+        return json.dumps({"error": f"Invalid email address: {email_address!r}"}, indent=2)
     data = mc_request(
         f"/lists/{list_id}/members/{subscriber_hash}/activity-feed",
         params={"count": count},
@@ -2959,7 +3064,9 @@ def list_member_notes(list_id: str, email_address: str, count: int = 20, offset:
         JSON with email_address, total_items, and notes array. Each note: id (use as note_id),
         note (string, the text), created_at, created_by, updated_at.
     """
-    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    subscriber_hash = _subscriber_hash(email_address)
+    if subscriber_hash is None:
+        return json.dumps({"error": f"Invalid email address: {email_address!r}"}, indent=2)
     data = mc_request(
         f"/lists/{list_id}/members/{subscriber_hash}/notes",
         params={"count": count, "offset": offset},
@@ -3002,7 +3109,9 @@ def add_member_note(list_id: str, email_address: str, note: str, account: str | 
     """
     if (guard := _guard_write(action="add member note", list_id=list_id, email_address=email_address, account=account)):
         return guard
-    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    subscriber_hash = _subscriber_hash(email_address)
+    if subscriber_hash is None:
+        return json.dumps({"error": f"Invalid email address: {email_address!r}"}, indent=2)
     data = mc_request(
         f"/lists/{list_id}/members/{subscriber_hash}/notes",
         body={"note": note},
@@ -3042,7 +3151,9 @@ def update_member_note(list_id: str, email_address: str, note_id: str, note: str
     """
     if (guard := _guard_write(action="update member note", list_id=list_id, email_address=email_address, note_id=note_id, account=account)):
         return guard
-    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    subscriber_hash = _subscriber_hash(email_address)
+    if subscriber_hash is None:
+        return json.dumps({"error": f"Invalid email address: {email_address!r}"}, indent=2)
     data = mc_request(
         f"/lists/{list_id}/members/{subscriber_hash}/notes/{note_id}",
         body={"note": note},
@@ -3080,7 +3191,9 @@ def delete_member_note(list_id: str, email_address: str, note_id: str, account: 
     """
     if (guard := _guard_write(action="delete member note", list_id=list_id, email_address=email_address, note_id=note_id, account=account)):
         return guard
-    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    subscriber_hash = _subscriber_hash(email_address)
+    if subscriber_hash is None:
+        return json.dumps({"error": f"Invalid email address: {email_address!r}"}, indent=2)
     result = mc_request(
         f"/lists/{list_id}/members/{subscriber_hash}/notes/{note_id}",
         method="DELETE",
@@ -4337,7 +4450,10 @@ def create_batch(operations: str, account: str | None = None) -> str:
     """
     if (guard := _guard_write(action="run batch operations", account=account)):
         return guard
-    ops = json.loads(operations)
+    try:
+        ops = json.loads(operations)
+    except json.JSONDecodeError as e:
+        return json.dumps({"error": f"Invalid operations: {e}"}, indent=2)
     data = mc_request("/batches", body={"operations": ops}, method="POST", account=account)
     return json.dumps({
         "id": data.get("id"),
@@ -5867,7 +5983,9 @@ def get_member_goals(list_id: str, email_address: str, account: str | None = Non
         JSON with total_items and goals array. Each: goal_id, event (the tracked value), last_visited_at
         (ISO 8601), data (the URL or event data). Returns error if the member is not found.
     """
-    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    subscriber_hash = _subscriber_hash(email_address)
+    if subscriber_hash is None:
+        return json.dumps({"error": f"Invalid email address: {email_address!r}"}, indent=2)
     data = mc_request(f"/lists/{list_id}/members/{subscriber_hash}/goals", account=account)
     return json.dumps(data, indent=2)
 
@@ -5894,7 +6012,9 @@ def add_member_event(list_id: str, email_address: str, name: str, properties: Op
     """
     if (guard := _guard_write(action="add member event", list_id=list_id, email_address=email_address, account=account)):
         return guard
-    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    subscriber_hash = _subscriber_hash(email_address)
+    if subscriber_hash is None:
+        return json.dumps({"error": f"Invalid email address: {email_address!r}"}, indent=2)
     body: dict = {"name": name}
     if properties is not None:
         body["properties"] = properties
@@ -5907,9 +6027,9 @@ def delete_member_permanent(list_id: str, email_address: str, account: str | Non
     """Permanently and irreversibly erase an audience member (GDPR-style deletion).
 
     IRREVERSIBLE: this permanently deletes all personal data for the member and prevents that
-    email from ever being re-imported into the audience. This differs from the archive-style
-    delete_member (which only archives the member and can be re-added); use delete_member unless
-    a true GDPR erasure is required.
+    email from ever being re-imported into the audience. This tool and delete_member are
+    equivalent: both call the same permanent-deletion endpoint. To merely stop sending while
+    keeping the member for reporting, use unsubscribe_member instead.
 
     Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
 
@@ -5924,7 +6044,9 @@ def delete_member_permanent(list_id: str, email_address: str, account: str | Non
     """
     if (guard := _guard_write(action="permanently delete member", list_id=list_id, email_address=email_address, account=account)):
         return guard
-    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    subscriber_hash = _subscriber_hash(email_address)
+    if subscriber_hash is None:
+        return json.dumps({"error": f"Invalid email address: {email_address!r}"}, indent=2)
     data = mc_request(f"/lists/{list_id}/members/{subscriber_hash}/actions/delete-permanent", method="POST", account=account)
     return json.dumps(data, indent=2)
 
@@ -5953,7 +6075,9 @@ def upsert_member(list_id: str, email_address: str, status_if_new: str = "subscr
     """
     if (guard := _guard_write(action="upsert member", list_id=list_id, email_address=email_address, account=account)):
         return guard
-    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    subscriber_hash = _subscriber_hash(email_address)
+    if subscriber_hash is None:
+        return json.dumps({"error": f"Invalid email address: {email_address!r}"}, indent=2)
     body: dict = {"email_address": email_address, "status_if_new": status_if_new}
     if merge_fields is not None:
         body["merge_fields"] = merge_fields
@@ -6186,7 +6310,9 @@ def get_automation_queue_subscriber(workflow_id: str, workflow_email_id: str, em
     Returns:
         JSON with the queued subscriber details.
     """
-    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    subscriber_hash = _subscriber_hash(email_address)
+    if subscriber_hash is None:
+        return json.dumps({"error": f"Invalid email address: {email_address!r}"}, indent=2)
     data = mc_request(f"/automations/{workflow_id}/emails/{workflow_email_id}/queue/{subscriber_hash}", account=account)
     return json.dumps(data, indent=2)
 
@@ -6253,7 +6379,9 @@ def get_automation_removed_subscriber(workflow_id: str, email_address: str, acco
     Returns:
         JSON with the removed subscriber details.
     """
-    subscriber_hash = hashlib.md5(email_address.lower().encode()).hexdigest()
+    subscriber_hash = _subscriber_hash(email_address)
+    if subscriber_hash is None:
+        return json.dumps({"error": f"Invalid email address: {email_address!r}"}, indent=2)
     data = mc_request(f"/automations/{workflow_id}/removed-subscribers/{subscriber_hash}", account=account)
     return json.dumps(data, indent=2)
 

--- a/src/mailchimp_mcp_server/server.py
+++ b/src/mailchimp_mcp_server/server.py
@@ -1055,7 +1055,9 @@ def delete_template(template_id: str, account: str | None = None) -> str:
     """
     if (guard := _guard_write(action="delete template", template_id=template_id, account=account)):
         return guard
-    mc_request(f"/templates/{template_id}", method="DELETE", account=account)
+    data = mc_request(f"/templates/{template_id}", method="DELETE", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "deleted", "template_id": template_id}, indent=2)
 
 
@@ -1262,8 +1264,8 @@ def tag_member(list_id: str, email_address: str, tags_to_add: Optional[str] = No
     tag/segment, add_member with tags param for tagging at signup, update_member for profile/status
     changes, get_member_tags to check current tags.
 
-    Authenticated via API key (read scope required). Max 10 concurrent requests. Respects
-    read-only and dry-run modes. Returns 404 error if the member does not exist.
+    Authenticated via API key. Max 10 concurrent requests. Respects read-only and dry-run modes.
+    Returns 404 error if the member does not exist.
 
     Args:
         list_id: Audience/list ID (10-char alphanumeric, e.g. 'abc123def4'). Obtain from list_audiences.
@@ -1690,7 +1692,9 @@ def schedule_campaign(campaign_id: str, schedule_time: str, account: str | None 
     """
     if (guard := _guard_write(action="schedule campaign", campaign_id=campaign_id, schedule_time=schedule_time, account=account)):
         return guard
-    mc_request(f"/campaigns/{campaign_id}/actions/schedule", body={"schedule_time": schedule_time}, method="POST", account=account)
+    data = mc_request(f"/campaigns/{campaign_id}/actions/schedule", body={"schedule_time": schedule_time}, method="POST", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "scheduled", "campaign_id": campaign_id, "schedule_time": schedule_time}, indent=2)
 
 
@@ -1718,7 +1722,9 @@ def unschedule_campaign(campaign_id: str, account: str | None = None) -> str:
     """
     if (guard := _guard_write(action="unschedule campaign", campaign_id=campaign_id, account=account)):
         return guard
-    mc_request(f"/campaigns/{campaign_id}/actions/unschedule", method="POST", account=account)
+    data = mc_request(f"/campaigns/{campaign_id}/actions/unschedule", method="POST", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "unscheduled", "campaign_id": campaign_id}, indent=2)
 
 
@@ -1779,7 +1785,9 @@ def delete_campaign(campaign_id: str, account: str | None = None) -> str:
     """
     if (guard := _guard_write(action="delete campaign", campaign_id=campaign_id, account=account)):
         return guard
-    mc_request(f"/campaigns/{campaign_id}", method="DELETE", account=account)
+    data = mc_request(f"/campaigns/{campaign_id}", method="DELETE", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "deleted", "campaign_id": campaign_id}, indent=2)
 
 
@@ -1808,7 +1816,9 @@ def send_campaign(campaign_id: str, account: str | None = None) -> str:
     """
     if (guard := _guard_write(action="send campaign", campaign_id=campaign_id, account=account)):
         return guard
-    mc_request(f"/campaigns/{campaign_id}/actions/send", method="POST", account=account)
+    data = mc_request(f"/campaigns/{campaign_id}/actions/send", method="POST", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "sent", "campaign_id": campaign_id}, indent=2)
 
 
@@ -1835,7 +1845,9 @@ def send_test_email(campaign_id: str, test_emails: str, send_type: str = "html",
         return guard
     email_list = [e.strip() for e in test_emails.split(",")]
     body = {"test_emails": email_list, "send_type": send_type}
-    mc_request(f"/campaigns/{campaign_id}/actions/test", body=body, method="POST", account=account)
+    data = mc_request(f"/campaigns/{campaign_id}/actions/test", body=body, method="POST", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "test_sent", "campaign_id": campaign_id, "test_emails": email_list}, indent=2)
 
 
@@ -1857,7 +1869,9 @@ def cancel_send(campaign_id: str, account: str | None = None) -> str:
     """
     if (guard := _guard_write(action="cancel campaign send", campaign_id=campaign_id, account=account)):
         return guard
-    mc_request(f"/campaigns/{campaign_id}/actions/cancel-send", method="POST", account=account)
+    data = mc_request(f"/campaigns/{campaign_id}/actions/cancel-send", method="POST", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "cancelled", "campaign_id": campaign_id}, indent=2)
 
 
@@ -1925,7 +1939,9 @@ def delete_segment(list_id: str, segment_id: str, account: str | None = None) ->
     """
     if (guard := _guard_write(action="delete segment", list_id=list_id, segment_id=segment_id, account=account)):
         return guard
-    mc_request(f"/lists/{list_id}/segments/{segment_id}", method="DELETE", account=account)
+    data = mc_request(f"/lists/{list_id}/segments/{segment_id}", method="DELETE", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "deleted", "segment_id": segment_id}, indent=2)
 
 
@@ -2273,7 +2289,9 @@ def delete_merge_field(list_id: str, merge_id: str, account: str | None = None) 
     """
     if (guard := _guard_write(action="delete merge field", list_id=list_id, merge_id=merge_id, account=account)):
         return guard
-    mc_request(f"/lists/{list_id}/merge-fields/{merge_id}", method="DELETE", account=account)
+    data = mc_request(f"/lists/{list_id}/merge-fields/{merge_id}", method="DELETE", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "deleted", "merge_id": merge_id}, indent=2)
 
 
@@ -2442,7 +2460,9 @@ def delete_interest_category(list_id: str, category_id: str, account: str | None
     """
     if (guard := _guard_write(action="delete interest category", list_id=list_id, category_id=category_id, account=account)):
         return guard
-    mc_request(f"/lists/{list_id}/interest-categories/{category_id}", method="DELETE", account=account)
+    data = mc_request(f"/lists/{list_id}/interest-categories/{category_id}", method="DELETE", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "deleted", "category_id": category_id}, indent=2)
 
 
@@ -2470,7 +2490,9 @@ def delete_interest(list_id: str, category_id: str, interest_id: str, account: s
     """
     if (guard := _guard_write(action="delete interest", list_id=list_id, category_id=category_id, interest_id=interest_id, account=account)):
         return guard
-    mc_request(f"/lists/{list_id}/interest-categories/{category_id}/interests/{interest_id}", method="DELETE", account=account)
+    data = mc_request(f"/lists/{list_id}/interest-categories/{category_id}/interests/{interest_id}", method="DELETE", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "deleted", "interest_id": interest_id}, indent=2)
 
 
@@ -2567,7 +2589,9 @@ def delete_webhook(list_id: str, webhook_id: str, account: str | None = None) ->
     """
     if (guard := _guard_write(action="delete webhook", list_id=list_id, webhook_id=webhook_id, account=account)):
         return guard
-    mc_request(f"/lists/{list_id}/webhooks/{webhook_id}", method="DELETE", account=account)
+    data = mc_request(f"/lists/{list_id}/webhooks/{webhook_id}", method="DELETE", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "deleted", "webhook_id": webhook_id}, indent=2)
 
 
@@ -3288,7 +3312,9 @@ def pause_automation(automation_id: str, account: str | None = None) -> str:
     """
     if (guard := _guard_write(action="pause automation", automation_id=automation_id, account=account)):
         return guard
-    mc_request(f"/automations/{automation_id}/actions/pause-all-emails", method="POST", account=account)
+    data = mc_request(f"/automations/{automation_id}/actions/pause-all-emails", method="POST", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "paused", "automation_id": automation_id}, indent=2)
 
 
@@ -3314,7 +3340,9 @@ def start_automation(automation_id: str, account: str | None = None) -> str:
     """
     if (guard := _guard_write(action="start automation", automation_id=automation_id, account=account)):
         return guard
-    mc_request(f"/automations/{automation_id}/actions/start-all-emails", method="POST", account=account)
+    data = mc_request(f"/automations/{automation_id}/actions/start-all-emails", method="POST", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "started", "automation_id": automation_id}, indent=2)
 
 
@@ -4703,12 +4731,14 @@ def trigger_customer_journey(journey_id: str, step_id: str, email_address: str, 
     """
     if (guard := _guard_write(action="trigger customer journey", journey_id=journey_id, step_id=step_id, email_address=email_address, account=account)):
         return guard
-    mc_request(
+    data = mc_request(
         f"/customer-journeys/journeys/{journey_id}/steps/{step_id}/actions/trigger",
         body={"email_address": email_address},
         method="POST",
         account=account,
     )
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "triggered", "journey_id": journey_id, "step_id": step_id, "email_address": email_address}, indent=2)
 
 
@@ -5142,7 +5172,9 @@ def delete_verified_domain(domain_name: str, account: str | None = None) -> str:
     """
     if (guard := _guard_write(action="delete verified domain", domain_name=domain_name, account=account)):
         return guard
-    mc_request(f"/verified-domains/{domain_name}", method="DELETE", account=account)
+    data = mc_request(f"/verified-domains/{domain_name}", method="DELETE", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "deleted", "domain_name": domain_name}, indent=2)
 
 
@@ -5231,7 +5263,9 @@ def delete_connected_site(connected_site_id: str, account: str | None = None) ->
     """
     if (guard := _guard_write(action="delete connected site", connected_site_id=connected_site_id, account=account)):
         return guard
-    mc_request(f"/connected-sites/{connected_site_id}", method="DELETE", account=account)
+    data = mc_request(f"/connected-sites/{connected_site_id}", method="DELETE", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "deleted", "connected_site_id": connected_site_id}, indent=2)
 
 
@@ -5471,7 +5505,9 @@ def delete_campaign_folder(folder_id: str, account: str | None = None) -> str:
     """
     if (guard := _guard_write(action="delete campaign folder", folder_id=folder_id, account=account)):
         return guard
-    mc_request(f"/campaign-folders/{folder_id}", method="DELETE", account=account)
+    data = mc_request(f"/campaign-folders/{folder_id}", method="DELETE", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "deleted", "folder_id": folder_id}, indent=2)
 
 
@@ -5581,7 +5617,9 @@ def delete_template_folder(folder_id: str, account: str | None = None) -> str:
     """
     if (guard := _guard_write(action="delete template folder", folder_id=folder_id, account=account)):
         return guard
-    mc_request(f"/template-folders/{folder_id}", method="DELETE", account=account)
+    data = mc_request(f"/template-folders/{folder_id}", method="DELETE", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "deleted", "folder_id": folder_id}, indent=2)
 
 
@@ -5724,7 +5762,9 @@ def delete_campaign_feedback(campaign_id: str, feedback_id: str, account: str | 
     """
     if (guard := _guard_write(action="delete campaign feedback", campaign_id=campaign_id, feedback_id=feedback_id, account=account)):
         return guard
-    mc_request(f"/campaigns/{campaign_id}/feedback/{feedback_id}", method="DELETE", account=account)
+    data = mc_request(f"/campaigns/{campaign_id}/feedback/{feedback_id}", method="DELETE", account=account)
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data, indent=2)
     return json.dumps({"status": "deleted", "campaign_id": campaign_id, "feedback_id": feedback_id}, indent=2)
 
 
@@ -7408,6 +7448,11 @@ def list_account_orders(count: int = 10, offset: int = 0, account: str | None = 
 # risk tier: irreversible data loss or an irreversible outbound send with wide blast radius.
 _DESTRUCTIVE_SEND = frozenset({"send_campaign", "resend_to_non_openers"})
 
+# Writes that are safe to repeat but whose names carry no delete_/upsert_ prefix, so the derived
+# rule below cannot infer them. Kept explicit (like _DESTRUCTIVE_SEND) so the idempotent hint
+# matches what each tool's docstring already states.
+_IDEMPOTENT_WRITES = frozenset({"update_member", "tag_member", "update_segment", "publish_landing_page"})
+
 
 def _classify_risk(name: str, fn) -> str:
     """Classify a tool as 'read', 'write', or 'destructive'.
@@ -7426,8 +7471,9 @@ def _classify_risk(name: str, fn) -> str:
 
 
 def _idempotent(name: str) -> bool:
-    """Deletes and PUT-based upserts are safe to repeat; other writes are not asserted idempotent."""
-    return name.startswith("delete_") or name.startswith("upsert_")
+    """Deletes, PUT-based upserts, and the explicitly-listed re-appliable updates are safe to
+    repeat; other writes are not asserted idempotent."""
+    return name.startswith("delete_") or name.startswith("upsert_") or name in _IDEMPOTENT_WRITES
 
 
 @mcp.tool()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,8 @@ def _reset_flags(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(server, "MAILCHIMP_DC", "us1")
     monkeypatch.setattr(server, "MAILCHIMP_BASE_URL", "https://us1.api.mailchimp.com/3.0")
     monkeypatch.setattr(server, "MAILCHIMP_ACCOUNTS", {})
+    # Retry backoff must never actually block the test suite.
+    monkeypatch.setattr(server.time, "sleep", lambda *args, **kwargs: None)
 
 
 @pytest.fixture

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -59,7 +59,7 @@ class TestArgumentValidation:
         mock_resp.status_code = 200
         mock_resp.ok = True
         mock_resp.json.return_value = {"account_name": "Acme"}
-        with patch.object(requests, "request", return_value=mock_resp):
+        with patch.object(requests.Session, "request", return_value=mock_resp):
             out = server.mc_request("/")
         assert out == {"account_name": "Acme"}
 
@@ -96,7 +96,7 @@ class TestAuditLog:
         mock_resp.status_code = 200
         mock_resp.ok = True
         mock_resp.json.return_value = {"lists": [], "total_items": 0}
-        with patch.object(requests, "request", return_value=mock_resp):
+        with patch.object(requests.Session, "request", return_value=mock_resp):
             server.list_audiences()
         events = _events(capsys.readouterr().err)
         match = [e for e in events if e["tool"] == "list_audiences"]
@@ -110,7 +110,7 @@ class TestAuditLog:
         mock_resp.status_code = 200
         mock_resp.ok = True
         mock_resp.json.return_value = {"id": 1}
-        with patch.object(requests, "request", return_value=mock_resp):
+        with patch.object(requests.Session, "request", return_value=mock_resp):
             server.upload_file(name="a.png", file_data="SUPERSECRETBASE64")
         err = capsys.readouterr().err
         assert "SUPERSECRETBASE64" not in err

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -51,7 +51,7 @@ class TestMcRequest:
         mock_resp.status_code = 200
         mock_resp.ok = True
         mock_resp.json.return_value = {"health_check": "Everything's Chimpy!"}
-        with patch.object(requests, "request", return_value=mock_resp) as mock_req:
+        with patch.object(requests.Session, "request", return_value=mock_resp) as mock_req:
             result = server.mc_request("/ping")
         assert result == {"health_check": "Everything's Chimpy!"}
         called_url = mock_req.call_args.args[1]
@@ -61,7 +61,7 @@ class TestMcRequest:
         mock_resp = MagicMock()
         mock_resp.status_code = 204
         mock_resp.ok = True
-        with patch.object(requests, "request", return_value=mock_resp):
+        with patch.object(requests.Session, "request", return_value=mock_resp):
             result = server.mc_request("/lists/abc/members/xyz", method="DELETE")
         assert result == {"status": "success"}
 
@@ -70,7 +70,7 @@ class TestMcRequest:
         mock_resp.status_code = 404
         mock_resp.ok = False
         mock_resp.json.return_value = {"title": "Resource Not Found", "detail": "List abc does not exist."}
-        with patch.object(requests, "request", return_value=mock_resp):
+        with patch.object(requests.Session, "request", return_value=mock_resp):
             result = server.mc_request("/lists/abc")
         assert result["error"] == "Resource Not Found"
         assert "does not exist" in result["detail"]
@@ -82,19 +82,19 @@ class TestMcRequest:
         mock_resp.ok = False
         mock_resp.json.side_effect = ValueError("not json")
         mock_resp.text = "Internal Server Error"
-        with patch.object(requests, "request", return_value=mock_resp):
+        with patch.object(requests.Session, "request", return_value=mock_resp):
             result = server.mc_request("/lists")
         assert "HTTP 500" in result["error"]
         assert "Internal Server Error" in result["detail"]
 
     def test_timeout_returns_error(self) -> None:
-        with patch.object(requests, "request", side_effect=requests.exceptions.Timeout):
+        with patch.object(requests.Session, "request", side_effect=requests.exceptions.Timeout):
             result = server.mc_request("/ping")
         assert "timed out" in result["error"].lower()
         assert result["endpoint"] == "/ping"
 
     def test_connection_error_returns_error(self) -> None:
-        with patch.object(requests, "request", side_effect=requests.exceptions.ConnectionError):
+        with patch.object(requests.Session, "request", side_effect=requests.exceptions.ConnectionError):
             result = server.mc_request("/ping")
         assert "connect" in result["error"].lower()
         assert result["endpoint"] == "/ping"
@@ -104,7 +104,7 @@ class TestMcRequest:
         mock_resp.status_code = 200
         mock_resp.ok = True
         mock_resp.json.return_value = {"id": "abc123"}
-        with patch.object(requests, "request", return_value=mock_resp) as mock_req:
+        with patch.object(requests.Session, "request", return_value=mock_resp) as mock_req:
             server.mc_request("/lists/abc/members", body={"email_address": "a@b.com"}, method="POST")
         args, kwargs = mock_req.call_args
         assert args[0] == "POST"
@@ -123,7 +123,7 @@ class TestMcRequestAccounts:
         mock_resp.status_code = 200
         mock_resp.ok = True
         mock_resp.json.return_value = {"ok": True}
-        with patch.object(requests, "request", return_value=mock_resp) as mock_req:
+        with patch.object(requests.Session, "request", return_value=mock_resp) as mock_req:
             server.mc_request("/lists", account="foo")
         called_url = mock_req.call_args.args[1]
         assert called_url == "https://us9.api.mailchimp.com/3.0/lists"
@@ -139,13 +139,13 @@ class TestMcRequestAccounts:
         mock_resp.status_code = 200
         mock_resp.ok = True
         mock_resp.json.return_value = {"ok": True}
-        with patch.object(requests, "request", return_value=mock_resp) as mock_req:
+        with patch.object(requests.Session, "request", return_value=mock_resp) as mock_req:
             server.mc_request("/lists")
         assert mock_req.call_args.args[1] == "https://us1.api.mailchimp.com/3.0/lists"
         assert mock_req.call_args.kwargs["auth"] == ("anystring", "test-key-us1")
 
     def test_unknown_account_returns_error_without_network(self) -> None:
-        with patch.object(requests, "request") as mock_req:
+        with patch.object(requests.Session, "request") as mock_req:
             result = server.mc_request("/lists", account="nope")
         assert "error" in result
         assert "nope" in result["error"]

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -1,0 +1,211 @@
+"""Tests for the reliability-hardening pass: error propagation on writes, JSON-argument
+guards, path-traversal rejection, PII redaction in the audit log, and batch bounds."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from mailchimp_mcp_server import server
+
+
+def _events(err: str) -> list[dict]:
+    return [json.loads(line) for line in err.splitlines() if line.strip().startswith("{")]
+
+
+class TestWriteErrorPropagation:
+    """A failing API call must surface the error, never a hard-coded success."""
+
+    def test_delete_member_surfaces_api_error(self, mock_mc_request) -> None:
+        mock_mc_request({"error": "Resource Not Found", "detail": "member gone", "status": 404})
+        payload = json.loads(server.delete_member(list_id="abc", email_address="j@co.com"))
+        assert payload.get("error") == "Resource Not Found"
+        assert payload.get("status") != "permanently_deleted"
+
+    def test_delete_member_confirms_on_success(self, mock_mc_request) -> None:
+        mock_mc_request({"status": "success"})
+        payload = json.loads(server.delete_member(list_id="abc", email_address="j@co.com"))
+        assert payload["status"] == "permanently_deleted"
+        assert payload["email_address"] == "j@co.com"
+
+    def test_tag_member_surfaces_api_error(self, mock_mc_request) -> None:
+        mock_mc_request({"error": "Resource Not Found", "status": 404})
+        payload = json.loads(server.tag_member(list_id="abc", email_address="j@co.com", tags_to_add="VIP"))
+        assert payload.get("error") == "Resource Not Found"
+        assert payload.get("status") != "updated"
+
+
+class TestJsonArgumentGuards:
+    """Malformed JSON in a string argument must return a readable error, not raise."""
+
+    def test_batch_subscribe_rejects_bad_json(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"new_members": []})
+        payload = json.loads(server.batch_subscribe(list_id="abc", members_json="{not json"))
+        assert "Invalid members_json" in payload["error"]
+        assert calls == []  # never dispatched
+
+    def test_create_segment_rejects_bad_json(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"id": "seg1"})
+        payload = json.loads(
+            server.create_segment(list_id="abc", name="S", match="all", conditions_json="[bad")
+        )
+        assert "Invalid conditions_json" in payload["error"]
+        assert calls == []
+
+    def test_update_segment_rejects_bad_json(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"id": "seg1"})
+        payload = json.loads(
+            server.update_segment(list_id="abc", segment_id="seg1", match="all", conditions_json="[bad")
+        )
+        assert "Invalid conditions_json" in payload["error"]
+        assert calls == []
+
+    def test_create_batch_rejects_bad_json(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"id": "batch1"})
+        payload = json.loads(server.create_batch(operations="{bad"))
+        assert "Invalid operations" in payload["error"]
+        assert calls == []
+
+
+class TestBatchBounds:
+    def test_batch_subscribe_rejects_over_500(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"new_members": []})
+        members = json.dumps([{"email_address": f"u{i}@co.com", "status": "subscribed"} for i in range(501)])
+        payload = json.loads(server.batch_subscribe(list_id="abc", members_json=members))
+        assert "max is 500" in payload["error"]
+        assert calls == []
+
+    def test_batch_subscribe_accepts_500(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"new_members": [], "updated_members": []})
+        members = json.dumps([{"email_address": f"u{i}@co.com", "status": "subscribed"} for i in range(500)])
+        server.batch_subscribe(list_id="abc", members_json=members)
+        assert len(calls) == 1
+
+
+class TestEmailValidation:
+    def test_malformed_email_rejected_without_network(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"status": "success"})
+        payload = json.loads(server.delete_member(list_id="abc", email_address="not-an-email"))
+        assert "Invalid email address" in payload["error"]
+        assert calls == []
+
+    def test_empty_email_rejected(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"status": "success"})
+        payload = json.loads(server.update_member(list_id="abc", email_address=""))
+        assert "Invalid email address" in payload["error"]
+        assert calls == []
+
+    def test_valid_email_dispatches(self, mock_mc_request) -> None:
+        calls = mock_mc_request({"status": "subscribed", "email_address": "j@co.com"})
+        server.unsubscribe_member(list_id="abc", email_address="j@co.com")
+        assert len(calls) == 1
+
+
+class TestOffsetValidation:
+    def test_negative_offset_rejected(self) -> None:
+        with patch.object(requests.Session, "request") as mock_req:
+            result = server.mc_request("/lists", params={"offset": -5, "count": 10})
+        assert "offset" in result["error"]
+        mock_req.assert_not_called()
+
+
+class TestPathTraversal:
+    def test_double_dot_segment_rejected_without_network(self) -> None:
+        with patch.object(requests.Session, "request") as mock_req:
+            result = server.mc_request("/lists/../../pool/members")
+        assert "error" in result
+        assert ".." in result["error"]
+        mock_req.assert_not_called()
+
+    def test_normal_path_still_allowed(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"ok": True}
+        with patch.object(requests.Session, "request", return_value=mock_resp) as mock_req:
+            result = server.mc_request("/lists/abc123/members")
+        assert result == {"ok": True}
+        mock_req.assert_called_once()
+
+
+def _resp(status: int, *, ok: bool | None = None, payload: dict | None = None, headers: dict | None = None) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status
+    r.ok = ok if ok is not None else status < 400
+    r.json.return_value = payload if payload is not None else {}
+    r.headers = headers or {}
+    return r
+
+
+class TestRetry:
+    def test_retries_429_then_succeeds(self) -> None:
+        seq = [_resp(429), _resp(200, payload={"ok": True})]
+        with patch.object(requests.Session, "request", side_effect=seq) as mock_req:
+            result = server.mc_request("/ping")
+        assert result == {"ok": True}
+        assert mock_req.call_count == 2
+
+    def test_retries_5xx_then_gives_up_with_error(self, monkeypatch) -> None:
+        monkeypatch.setattr(server, "MAX_RETRIES", 3)
+        r = _resp(503)
+        r.json.side_effect = ValueError("not json")
+        r.text = "Service Unavailable"
+        with patch.object(requests.Session, "request", return_value=r) as mock_req:
+            result = server.mc_request("/ping")
+        assert "HTTP 503" in result["error"]
+        assert mock_req.call_count == 4  # initial + 3 retries
+
+    def test_honors_retry_after_header(self, monkeypatch) -> None:
+        waits: list[float] = []
+        monkeypatch.setattr(server.time, "sleep", lambda s: waits.append(s))
+        seq = [_resp(429, headers={"Retry-After": "2"}), _resp(200, payload={"ok": True})]
+        with patch.object(requests.Session, "request", side_effect=seq):
+            server.mc_request("/ping")
+        assert waits == [2.0]
+
+    def test_no_retry_on_success(self) -> None:
+        with patch.object(requests.Session, "request", return_value=_resp(200, payload={"ok": True})) as mock_req:
+            server.mc_request("/ping")
+        assert mock_req.call_count == 1
+
+    def test_timeout_not_retried(self) -> None:
+        with patch.object(requests.Session, "request", side_effect=requests.exceptions.Timeout) as mock_req:
+            result = server.mc_request("/ping")
+        assert "timed out" in result["error"].lower()
+        assert mock_req.call_count == 1  # writes may have landed; never replayed
+
+
+class TestSessionPooling:
+    def test_session_reused_per_account(self) -> None:
+        server._SESSIONS.clear()
+        with patch.object(requests.Session, "request", return_value=_resp(200, payload={"ok": True})):
+            server.mc_request("/ping")
+            server.mc_request("/lists")
+        assert set(server._SESSIONS) == {"default"}
+
+
+class TestAuditPiiRedaction:
+    def test_top_level_email_redacted(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(server, "AUDIT_LOG", True)
+        monkeypatch.setattr(server, "READ_ONLY", True)
+        server.delete_member(list_id="abc", email_address="jane@secret.com")
+        err = capsys.readouterr().err
+        assert "jane@secret.com" not in err
+        assert "<redacted>" in err
+
+    def test_nested_member_emails_redacted_in_executed_event(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(server, "AUDIT_LOG", True)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"new_members": [], "updated_members": []}
+        members = json.dumps(
+            [{"email_address": "buried@secret.com", "status": "subscribed", "merge_fields": {"FNAME": "Jane"}}]
+        )
+        with patch.object(requests.Session, "request", return_value=mock_resp):
+            server.batch_subscribe(list_id="abc", members_json=members)
+        err = capsys.readouterr().err
+        assert "buried@secret.com" not in err
+        assert "Jane" not in err

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
 import requests
 
 from mailchimp_mcp_server import server
@@ -35,6 +36,41 @@ class TestWriteErrorPropagation:
         payload = json.loads(server.tag_member(list_id="abc", email_address="j@co.com", tags_to_add="VIP"))
         assert payload.get("error") == "Resource Not Found"
         assert payload.get("status") != "updated"
+
+
+# Write tools whose success payload was previously hard-coded regardless of the API outcome.
+# (tool callable, kwargs, the success-status string that must NOT appear on a failed call)
+_HARDCODED_WRITES = [
+    (lambda: server.send_campaign(campaign_id="c1"), "sent"),
+    (lambda: server.send_test_email(campaign_id="c1", test_emails="a@b.com"), "test_sent"),
+    (lambda: server.schedule_campaign(campaign_id="c1", schedule_time="2026-01-01T00:00:00Z"), "scheduled"),
+    (lambda: server.unschedule_campaign(campaign_id="c1"), "unscheduled"),
+    (lambda: server.cancel_send(campaign_id="c1"), "cancelled"),
+    (lambda: server.delete_campaign(campaign_id="c1"), "deleted"),
+    (lambda: server.delete_template(template_id="t1"), "deleted"),
+    (lambda: server.delete_segment(list_id="l1", segment_id="s1"), "deleted"),
+    (lambda: server.delete_webhook(list_id="l1", webhook_id="w1"), "deleted"),
+    (lambda: server.pause_automation(automation_id="a1"), "paused"),
+    (lambda: server.start_automation(automation_id="a1"), "started"),
+    (lambda: server.trigger_customer_journey(journey_id="j1", step_id="s1", email_address="a@b.com"), "triggered"),
+]
+
+
+class TestHardCodedWriteResults:
+    """The 20 write/destructive tools that discarded mc_request's result must now surface errors."""
+
+    @pytest.mark.parametrize("call, success_status", _HARDCODED_WRITES)
+    def test_surfaces_api_error(self, mock_mc_request, call, success_status) -> None:
+        mock_mc_request({"error": "Bad Request", "detail": "already sent", "status": 400})
+        payload = json.loads(call())
+        assert payload.get("error") == "Bad Request"
+        assert payload.get("status") != success_status
+
+    def test_send_campaign_confirms_on_success(self, mock_mc_request) -> None:
+        mock_mc_request({"status": "success"})
+        payload = json.loads(server.send_campaign(campaign_id="c1"))
+        assert payload["status"] == "sent"
+        assert payload["campaign_id"] == "c1"
 
 
 class TestJsonArgumentGuards:
@@ -128,6 +164,35 @@ class TestPathTraversal:
             result = server.mc_request("/lists/abc123/members")
         assert result == {"ok": True}
         mock_req.assert_called_once()
+
+
+class TestMetadataTruthfulness:
+    """Docstrings must not contradict the machine-readable risk/idempotency signals."""
+
+    def test_no_tool_claims_read_scope_for_a_write(self) -> None:
+        # A2: 'read scope required' appeared on tag_member, a write. It should exist nowhere.
+        import inspect
+
+        for name, risk in server.TOOL_RISK.items():
+            fn = getattr(server, name)
+            doc = inspect.getdoc(fn) or ""
+            assert "read scope required" not in doc, f"{name} ({risk}) claims read scope"
+
+    @pytest.mark.parametrize(
+        "name", ["update_member", "tag_member", "update_segment", "publish_landing_page"]
+    )
+    def test_idempotent_prose_matches_annotation(self, name) -> None:
+        # B1: these tools say "Idempotent" in prose; the machine hint must agree.
+        import inspect
+
+        doc = inspect.getdoc(getattr(server, name)) or ""
+        assert "idempotent" in doc.lower()
+        assert server._idempotent(name) is True
+
+    def test_describe_tools_reports_idempotent_for_these(self) -> None:
+        by_name = {t["name"]: t for t in json.loads(server.describe_tools())["tools"]}
+        for name in ("update_member", "tag_member", "update_segment", "publish_landing_page"):
+            assert by_name[name]["idempotent"] is True
 
 
 def _resp(status: int, *, ok: bool | None = None, payload: dict | None = None, headers: dict | None = None) -> MagicMock:

--- a/tests/test_tools_smoke.py
+++ b/tests/test_tools_smoke.py
@@ -829,7 +829,7 @@ class TestAccounts:
         mock_resp.status_code = 200
         mock_resp.ok = True
         mock_resp.json.return_value = {"lists": [], "total_items": 0}
-        with patch.object(requests, "request", return_value=mock_resp) as mock_req:
+        with patch.object(requests.Session, "request", return_value=mock_resp) as mock_req:
             server.list_audiences(account="foo")
         assert mock_req.call_args.args[1].startswith("https://us9.api.mailchimp.com/3.0/")
         assert mock_req.call_args.kwargs["auth"] == ("anystring", "fookey-us9")


### PR DESCRIPTION
Hardens the server against transient failures and closes a class of correctness bugs where tools reported success that never happened. No tool signatures change; valid calls behave exactly as before. 186 tests pass, ruff clean.

## Correctness

Write and destructive tools discarded the API result and returned a hard-coded success. A rejected `send_campaign` was reported as `sent`, a failed `delete_campaign` as `deleted`, a failed GDPR `delete_member` as `permanently_deleted`. Around 20 tools were affected (the whole `delete_*` family, `send_campaign`, `send_test_email`, `schedule_campaign`, `unschedule_campaign`, `cancel_send`, `pause_automation`, `start_automation`, `trigger_customer_journey`, ...). Each now returns the API error its docstring already promised.

Other correctness fixes:
- Malformed JSON on `batch_subscribe`, `create_segment`, `update_segment`, `create_batch` returns a readable error instead of raising.
- Email format is validated before use, so a bad address returns a clear error instead of a confusing 404 against a hash matching no member. Deduplicates the subscriber-hash logic across 18 call sites.
- `batch_subscribe` enforces its documented 500-member cap; `offset` must be zero or greater.

## Robustness

- Automatic retries on 429 and 5xx with exponential backoff, honoring `Retry-After`. Configurable via `MAILCHIMP_MAX_RETRIES` (default 3). Network timeouts are not retried, so a write that may already have landed is never replayed.
- One keep-alive `requests.Session` per account, so sequential calls reuse the connection instead of reconnecting each time.

## Security

- Audit log redacts subscriber PII (`email_address`, `email`, `merge_fields`) at any depth, including inside `batch_subscribe` member arrays. Previously only `file_data` was masked.
- Path parameters containing `..` are rejected before dispatch, closing an endpoint-traversal gap the empty-segment (`//`) check missed.

## Metadata truthfulness

- `tag_member` no longer claims "read scope required" (it is a write).
- The `idempotent` hint now agrees with the docstrings for `update_member`, `tag_member`, `update_segment`, `publish_landing_page`. Regression tests lock both invariants.

## Docs

- Corrected the contradictory `delete_member` / `delete_member_permanent` docs (both hit the same permanent-deletion endpoint).
- Removed a stale internal note from `smithery.yaml`.