### PR TITLE
chore: publish Docker image to GHCR and harden the release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: uv run python -c "from mailchimp_mcp_server.server import mcp; print('Server loaded successfully')"
 
       - name: Run tests with coverage
-        run: uv run pytest --cov=mailchimp_mcp_server --cov-report=xml --cov-report=term
+        run: uv run pytest --cov=mailchimp_mcp_server --cov-report=xml --cov-report=term --cov-fail-under=50
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.13'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,42 @@
+name: Publish Docker image
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+jobs:
+  docker:
+    name: Build and push to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write  # push to the GitHub Container Registry with the built-in token
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/mailchimp-mcp-server
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,8 +7,34 @@ on:
   workflow_dispatch:
 
 jobs:
+  test:
+    name: Test before publish (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Lint with ruff
+        run: uv run ruff check src/ tests/
+
+      - name: Run tests
+        run: uv run pytest --cov=mailchimp_mcp_server --cov-report=term --cov-fail-under=50
+
   publish:
     name: Build and publish to PyPI
+    needs: test  # never publish a release the test matrix has not passed
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -23,6 +49,17 @@ jobs:
 
       - name: Set up Python
         run: uv python install 3.13
+
+      - name: Verify tag matches package version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$TAG" != "$PKG" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match pyproject version $PKG" >&2
+            exit 1
+          fi
+          echo "Tag matches version $PKG"
 
       - name: Build distribution
         run: uv build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same permanent-deletion endpoint and are equivalent.
 
 ### Added
+- **Docker image** — a prebuilt image is published to the GitHub Container Registry
+  (`ghcr.io/damientilman/mailchimp-mcp-server`) on every release, for running the server without
+  a local Python or uv install. README documents both the `docker run` and MCP-client setups.
 - **Response size cap** — a campaign's HTML/plain-text body is capped before it reaches the model
   so one large template can't blow the context window. Configurable via
   `MAILCHIMP_MAX_CONTENT_CHARS` (default 100000; `0` disables). When a body is trimmed, the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,8 @@ uv run ruff check src/ tests/      # lint
 uv run ruff format src/ tests/     # format
 ```
 
-CI will fail on lint or format violations, so run these before opening a PR.
+CI runs `ruff check` and fails on lint violations, so run it before opening a PR. Formatting is
+not enforced in CI, but running `ruff format` keeps diffs clean.
 
 ## Adding a New Tool
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![MCP](https://img.shields.io/badge/MCP-compatible-green.svg)](https://modelcontextprotocol.io)
+[![Docker](https://img.shields.io/badge/ghcr.io-mailchimp--mcp--server-blue?logo=docker)](https://github.com/damientilman/mailchimp-mcp-server/pkgs/container/mailchimp-mcp-server)
 
 The most complete [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/): **227 tools** to query and manage your Mailchimp account from any MCP-compatible client. It covers the full campaign, audience, member, segment, automation and reporting surface, complete e-commerce (read and write), landing pages, File Manager, surveys, signup forms and verified domains, plus multi-account support and runtime-security guardrails (read-only, dry-run and audit modes, with per-tool risk metadata).
 
@@ -43,6 +44,31 @@ Add it to your MCP client (Claude Desktop, Cursor, Cline, …):
 ```
 
 Tip: start with `MAILCHIMP_READ_ONLY=true` to explore safely, then flip it off when you are ready to write. See [Configuration](#configuration) for all options.
+
+### Docker
+
+A prebuilt image is published to the GitHub Container Registry on every release:
+
+```bash
+docker run --rm -i -e MAILCHIMP_API_KEY=your-key-us8 ghcr.io/damientilman/mailchimp-mcp-server:latest
+```
+
+Or point your MCP client at it:
+
+```json
+{
+  "mcpServers": {
+    "mailchimp": {
+      "command": "docker",
+      "args": ["run", "--rm", "-i", "-e", "MAILCHIMP_API_KEY", "-e", "MAILCHIMP_READ_ONLY", "ghcr.io/damientilman/mailchimp-mcp-server:latest"],
+      "env": {
+        "MAILCHIMP_API_KEY": "your-key-us8",
+        "MAILCHIMP_READ_ONLY": "true"
+      }
+    }
+  }
+}
+```
 
 ## Features
 

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -191,6 +191,15 @@ class TestResponseVolumeBounds:
         assert "truncated" not in payload
 
 
+class TestAdvertisedToolCount:
+    # The number below is advertised in README.md and glama.json. Bump all three together when
+    # adding or removing tools; this test fails on drift so the marketing count can't go stale.
+    ADVERTISED = 227
+
+    def test_tool_count_matches_advertised(self) -> None:
+        assert len(server.TOOL_RISK) == self.ADVERTISED
+
+
 class TestBatchRiskTier:
     def test_create_batch_is_destructive(self) -> None:
         assert server.TOOL_RISK["create_batch"] == "destructive"


### PR DESCRIPTION
Adoption and release-safety improvements. No library behavior changes. 193 tests pass, ruff clean.

## Docker distribution

New `docker.yml` workflow builds the existing Dockerfile and pushes a multi-tag image (`{version}`, `{major}.{minor}`, `latest`) to the GitHub Container Registry on each release tag. It uses the built-in `GITHUB_TOKEN`, so there are no external registry secrets to configure. The README gains a registry badge and a Docker section covering both `docker run` and MCP-client setups.

## Safer releases

- The PyPI publish job now depends on the full test matrix (3.10-3.13) passing first, so a tag can never ship code the tests have not vetted.
- A pre-publish step verifies the git tag matches the `pyproject.toml` version, preventing tag/version drift.

## CI and housekeeping

- CI enforces a coverage floor (`--cov-fail-under=50`; current is ~53%) so coverage can't silently rot.
- A test locks the advertised 227-tool count, so adding a tool without updating the README/glama count fails CI.
- Corrected the CONTRIBUTING note that claimed CI enforces formatting; CI runs `ruff check` (lint) only, and the doc now says so.