### PR TITLE
release: v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-06
+
 ### Fixed
 - Every write and destructive tool now surfaces the API error instead of reporting a hard-coded
   success. Around 20 tools — including `send_campaign`, `send_test_email`, `schedule_campaign`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mailchimp-mcp"
-version = "1.0.0"
+version = "1.1.0"
 description = "MCP server for the Mailchimp Marketing API — access campaigns, audiences, reports, and more from any MCP-compatible client."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Cuts v1.1.0. Bumps the version to 1.1.0 and rolls the accumulated Unreleased notes into a dated 1.1.0 section. Minor bump: new features and fixes, no breaking changes to tool signatures.

Highlights since 1.0.0:
- Correctness: ~20 write/destructive tools that reported a hard-coded success now surface real API errors (a rejected `send_campaign` no longer reads as `sent`).
- Robustness: automatic retries on 429/5xx, per-account connection pooling, a response-size cap that protects the model's context window.
- Distribution: a Docker image on GHCR each release, plus a hardened release pipeline (publish gated on the test matrix and a tag/version match).
- Metadata: `create_batch` is now `destructive`; scope and idempotency hints match their docstrings.

Tagging `v1.1.0` after merge will publish to PyPI and push the Docker image to GHCR.