### PR TITLE
fix: copy README.md in Docker build so the image builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,3 +66,5 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true  # a re-run for an already-published version is a no-op, not a failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Docker build now copies `README.md`, which `pyproject.toml` references, so the image builds
+  instead of failing metadata generation. The PyPI publish also skips already-published versions
+  on re-run rather than erroring.
+
 ## [1.1.0] - 2026-07-06
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.13-slim AS builder
 
 WORKDIR /build
 
-COPY pyproject.toml ./
+COPY pyproject.toml README.md ./
 COPY src/ src/
 
 RUN pip install --no-cache-dir --target=/install .


### PR DESCRIPTION
The v1.1.0 Docker publish failed: the Dockerfile copied only `pyproject.toml` and `src/`, but `pyproject.toml` sets `readme = "README.md"`, so hatchling metadata generation failed with `OSError: Readme file does not exist: README.md`. This had never surfaced because the image was never actually built before the GHCR workflow existed.

- Copy `README.md` into the build context.
- Set `skip-existing: true` on the PyPI publish so re-triggering a tag for an already-published version is a no-op instead of a red run.

PyPI 1.1.0 published fine; this fixes the Docker half. After merge the v1.1.0 tag will be re-pointed here to build and push the image.